### PR TITLE
difficulty test example [EXAMPLE]

### DIFF
--- a/DifficultyTests/dfExample/difficultyExample.json
+++ b/DifficultyTests/dfExample/difficultyExample.json
@@ -1,0 +1,113 @@
+{
+    "difficultyExample" : {
+        "_info" : {
+            "comment" : "Difficulty Formula range check",
+            "filling-rpc-server" : "evm version 1.10.11-unstable-9d377a96-20211019",
+            "filling-tool-version" : "retesteth-0.2.0-memory+commit.3d82e09f.Linux.g++",
+            "generatedTestHash" : "2d8bfbe490854753d47daf25fe87be73e4090862db74b214591b113f18667a73",
+            "lllcversion" : "Version: 0.5.14-develop.2021.6.15+commit.401d5358.Linux.g++",
+            "source" : "src/DifficultyTestsFiller/dfExample/difficultyExampleFiller.json",
+            "sourceHash" : "a5ffbfb66eebaf38074b42a61d4477f29acb180846a49c986051430bb4708995"
+        },
+        "Berlin" : {
+            "difficultyExample-0" : {
+                "currentBlockNumber" : "0x0186a0",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-1" : {
+                "currentBlockNumber" : "0x0186a0",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-2" : {
+                "currentBlockNumber" : "0x0186a5",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-3" : {
+                "currentBlockNumber" : "0x0186a5",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-4" : {
+                "currentBlockNumber" : "0x0186aa",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-5" : {
+                "currentBlockNumber" : "0x0186aa",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            }
+        },
+        "London" : {
+            "difficultyExample-10" : {
+                "currentBlockNumber" : "0x0186aa",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-11" : {
+                "currentBlockNumber" : "0x0186aa",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-6" : {
+                "currentBlockNumber" : "0x0186a0",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-7" : {
+                "currentBlockNumber" : "0x0186a0",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-8" : {
+                "currentBlockNumber" : "0x0186a5",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x01",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            },
+            "difficultyExample-9" : {
+                "currentBlockNumber" : "0x0186a5",
+                "currentDifficulty" : "0x0201d7",
+                "currentTimestamp" : "0x02",
+                "parentDifficulty" : "0x020157",
+                "parentTimestamp" : "0x00",
+                "parentUncles" : "0x01"
+            }
+        }
+    }
+}

--- a/src/DifficultyTestsFiller/dfExample/difficultyExampleFiller.json
+++ b/src/DifficultyTestsFiller/dfExample/difficultyExampleFiller.json
@@ -1,0 +1,17 @@
+{
+    "difficultyExample" : 
+    {
+        "_info" : {
+            "comment" : "Difficulty Formula range check"
+        },
+        "network" : [ ">=Berlin"],
+        "//comment" : "[ from x - to y ; with step z]",
+        "blocknumber" : "[100000-100010;5]",
+        "timestampDiff" : "[1-2;1]",
+        "//comment" : "or array of fixed elements",
+        "parentDifficutly" : ["131415"],
+        "//comment" : "only 2 elements. only 0 or 1 [0, 1]",
+        "hasUncles" : [1]
+    }
+}
+


### PR DESCRIPTION
retesteth develop branch: https://github.com/ethereum/retesteth/pull/152

Here some comments: 
```
# Test generate for all provided networks
        "network" : [ "London"],
# For blocknumbers from  B1 to B2 with step dB   // or array of values
        "blocknumber" : "[100000-100010;5]",
# For timestamp intervals from  T1 to T2 with step dT // or array of values
        "timestampDiff" : "[1-2;1]",
# For parentDifficulty intervals from  PD1 to PD2 with step dPD // or array of values
        "parentDifficutly" : ["131415"],
# For current block having number of uncles (array of values, max 2 values)
        "hasUncles" : [1]
```

the test calculate difficulty formula given above input parameters using `geth evm t8n` 