### PR TITLE
Add Expected Error to Existing HighNonce Test

### DIFF
--- a/TransactionTests/ttNonce/TransactionWithHighNonce64Minus1.json
+++ b/TransactionTests/ttNonce/TransactionWithHighNonce64Minus1.json
@@ -2,63 +2,53 @@
     "TransactionWithHighNonce64Minus1" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-unstable-291393c2",
-            "filling-tool-version" : "retesteth-0.2.0-memory+commit.093d78f6.Linux.g++",
-            "generatedTestHash" : "77b14731568f75023c39cc84b69b199cb89729365acca2b47667e5b6541616dd",
+            "filling-rpc-server" : "evm version 1.10.13-unstable-33f28138",
+            "filling-tool-version" : "retesteth-0.2.0-memory+commit.751fc83d.Linux.g++",
+            "generatedTestHash" : "4dab12dc9ea42953292ee903b77393f8ae61358a6a2fe5333f1ca284f2968ae0",
             "lllcversion" : "Version: 0.5.14-develop.2021.10.5+commit.401d5358.Linux.g++",
             "source" : "src/TransactionTestsFiller/ttNonce/TransactionWithHighNonce64Minus1Filler.json",
-            "sourceHash" : "aef38d4686eed705817fb306a7ff718960ad38c11cfbc245ffd9520737676689"
+            "sourceHash" : "8206748e794a51284f5918884d0113e36ee132d52cf98d6a9b4ca420aecebc25"
         },
         "result" : {
             "Berlin" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "Byzantium" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "Constantinople" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "ConstantinopleFix" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "EIP150" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "EIP158" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "Frontier" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "Homestead" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "Istanbul" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             },
             "London" : {
-                "hash" : "0xff46a9a2dec8abf0cbab16a9ff4b9c5466bb33670c38720bfe441cf3974c2337",
-                "intrinsicGas" : "0x5208",
-                "sender" : "0x93d7386c0a9f0a50d82ec70ef9580889ae4502b1"
+                "exception" : "NonceMax",
+                "intrinsicGas" : "0x5208"
             }
         },
         "txbytes" : "0xf86788ffffffffffffffff0182520894095e7baea6a6c7c4c2dfeb977efac326af552d8780801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a01fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804"

--- a/src/TransactionTestsFiller/ttNonce/TransactionWithHighNonce64Minus1Filler.json
+++ b/src/TransactionTestsFiller/ttNonce/TransactionWithHighNonce64Minus1Filler.json
@@ -3,6 +3,7 @@
     {
         "expectException" : 
         {
+            ">=Frontier": "NonceMax"
         },
         "transaction" :
         {


### PR DESCRIPTION
This PR adds an expected error to an existing HighNonce test.

This is just a single one of the changes in #934, in order to have none of the tests failing and be able to make the release.