### PR TITLE
Add state tests for RANDOM opcode

### DIFF
--- a/GeneralStateTests/stMerge/randomOpcode.json
+++ b/GeneralStateTests/stMerge/randomOpcode.json
@@ -1,0 +1,98 @@
+{
+    "randomOpcode" : {
+        "_info" : {
+            "comment" : "",
+            "filling-rpc-server" : "evm version 1.10.14-unstable-8253191d-20220107",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.167fb1fa.Linux.g++",
+            "generatedTestHash" : "a24d874d7010cdc4519895b6a297c76db388a41dc6c8ab2d252888c21c179d75",
+            "lllcversion" : "Version: 0.5.14-develop.2021.10.5+commit.401d5358.Linux.g++",
+            "solidity" : "Version: 0.8.5+commit.a4f2e591.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stMerge/randomOpcodeFiller.yml",
+            "sourceHash" : "132f63a2a5085396ec8bcc89b3d727bf0fa7a686b57eff95fcd16e593bfe39ee"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x00",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [
+                {
+                    "hash" : "0xcba8324df4b21e6bece341293f565ae39e73ea2ffa3c521cb4afdac74d4909f9",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf861800a84042c1d8094cccccccccccccccccccccccccccccccccccccccc80801ba0614a49be158e7994f0e40e441a1670ca8ef2026bfc6476d3d1826fe0bca01af0a01a64b3ab17374f42b302e54ccfbd64ffdfa1876eb184992867dc015eabd0e1f3"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" : {
+                "balance" : "0x00",
+                "code" : "0x7f0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef441415602c5760006000f35b60006000fd",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" : {
+                "balance" : "0x00",
+                "code" : "0x4160005542600155436002554460035545600455",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x416000554260015543600255446003554560045573bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb803b8060006000843c8060006000f050448160006000f55073bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb915060006000600060006000865af15073dddddddddddddddddddddddddddddddddddddddd915060006000600060006000865af15073eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee915060006000600060006000865af15073aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa91506000600060006000855afa6005555050",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xdddddddddddddddddddddddddddddddddddddddd" : {
+                "balance" : "0x00",
+                "code" : "0x73bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb6000600060006000845af45050",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" : {
+                "balance" : "0x00",
+                "code" : "0x73bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb60006000600060006000855af25050",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x042c1d80"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stMerge/randomOpcodeInit.json
+++ b/GeneralStateTests/stMerge/randomOpcodeInit.json
@@ -1,0 +1,63 @@
+{
+    "randomOpcodeInit" : {
+        "_info" : {
+            "comment" : "",
+            "filling-rpc-server" : "evm version 1.10.14-unstable-8253191d-20220107",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.167fb1fa.Linux.g++",
+            "generatedTestHash" : "2d23c1078cf69449d3895d6f89d81ad5dfd36d36010b242963f3ae2725d76087",
+            "lllcversion" : "Version: 0.5.14-develop.2021.10.5+commit.401d5358.Linux.g++",
+            "solidity" : "Version: 0.8.5+commit.a4f2e591.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stMerge/randomOpcodeInitFiller.yml",
+            "sourceHash" : "4cffc7dc19b7fa2e728ef656c1f2b379d73e293bead50d60d9560b62c7326e94"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x00",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [
+                {
+                    "hash" : "0x306f0e191c3ba725b229f19fcb0e674ace9da12a1867884103e73c02c4032a8b",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf861800a84042c1d8080809441600055426001554360025544600355456004551ca013a18aec31dccf517e135eb82aa0d4846bac6ce4885f27b8e0440aaca14dfa9da025f8b2b08581ccab0f14cbf8d854a2a069b9779277f22c068837e2e271c338af"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x4160005542600155436002554460035545600455"
+            ],
+            "gasLimit" : [
+                "0x042c1d80"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stMerge/randomOpcodeFiller.yml
+++ b/src/GeneralStateTestsFiller/stMerge/randomOpcodeFiller.yml
@@ -1,0 +1,169 @@
+# Verifies RANDOM (Previously DIFFICULTY) opcode post-merge state in different EVM contexts.
+randomOpcode:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x00'
+    currentRandom: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    currentGasLimit: '89128960'
+    currentBaseFee: '10'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: 1000000000
+      code: ''
+      nonce: 0
+      storage: {}
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+      balance: 0
+      code: |
+        :yul
+        {
+          if eq(difficulty(), 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef) {
+            return(0, 0)
+          }
+          revert(0, 0)
+        }
+      nonce: '0x01'
+      storage: {}
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:
+      balance: 0
+      code: |
+        :yul
+        {
+          // Store all opcodes coming from the block header to verify nothing else is affected.
+          sstore(0, coinbase())
+          sstore(1, timestamp())
+          sstore(2, number())
+          sstore(3, difficulty())
+          sstore(4, gaslimit())
+        }
+      nonce: '0x01'
+      storage: {}
+    cccccccccccccccccccccccccccccccccccccccc:
+      balance: 0
+      code: |
+        :yul
+        {
+          // Store all opcodes coming from the block header to verify nothing else is affected.
+          sstore(0, coinbase())
+          sstore(1, timestamp())
+          sstore(2, number())
+          sstore(3, difficulty())
+          sstore(4, gaslimit())
+
+          // Get the random opcode during initcode execution of CREATE opcode
+          let addr := 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          let isize := extcodesize(addr)
+          extcodecopy(addr, 0, 0, isize)
+          pop(create(0, 0, isize))
+
+          // Get the random opcode during initcode execution of CREATE2 opcode
+          pop(create2(0, 0, isize, difficulty()))
+
+          // Random Opcode in Call
+          addr := 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          pop(call(gas(), addr, 0, 0, 0, 0, 0))
+
+          // Random Opcode in DelegateCall (Delegate-called from subcall)
+          addr := 0xdddddddddddddddddddddddddddddddddddddddd
+          pop(call(gas(), addr, 0, 0, 0, 0, 0))
+
+          // Random Opcode in CallCode (Code-called from subcall)
+          addr := 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+          pop(call(gas(), addr, 0, 0, 0, 0, 0))
+
+          // Static call contract that reverts if difficulty is unexpected value
+          addr := 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          sstore(5, staticcall(gas(), addr, 0, 0, 0, 0))
+        }
+      nonce: '0x01'
+      storage: {}
+    
+    dddddddddddddddddddddddddddddddddddddddd:
+      balance: 0
+      code: |
+        :yul
+        {
+          let addr := 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          pop(delegatecall(gas(), addr, 0, 0, 0, 0))
+        }
+      nonce: '0x01'
+      storage: {}
+
+    eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:
+      balance: 0
+      code: |
+        :yul
+        {
+          let addr := 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          pop(callcode(gas(), addr, 0, 0, 0, 0, 0))
+        }
+      nonce: '0x01'
+      storage: {}
+
+  transaction:
+    data: 
+      - ''
+    gasLimit:
+      - 70000000
+    gasPrice: 10
+    nonce: 0
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'cccccccccccccccccccccccccccccccccccccccc'
+    value:
+    - 0
+
+  expect:
+    - indexes:
+       data: !!int -1
+       gas: !!int -1
+       value: !!int -1
+      network:
+        - '>=London'
+      result:
+       a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          nonce: 1
+       cccccccccccccccccccccccccccccccccccccccc:
+          nonce: '0x03'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'
+            '5': '0x01'
+       553e6c30af61e7a3576f31311ea8a620f80d047e:
+          nonce: '0x01'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'
+       1c2ebaf67c01ee868a6ed9b37e7f89934ba559e1:
+          nonce: '0x01'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'
+       dddddddddddddddddddddddddddddddddddddddd:
+          nonce: '0x01'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'
+       eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:
+          nonce: '0x01'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'

--- a/src/GeneralStateTestsFiller/stMerge/randomOpcodeInitFiller.yml
+++ b/src/GeneralStateTestsFiller/stMerge/randomOpcodeInitFiller.yml
@@ -1,0 +1,59 @@
+# Verifies RANDOM (Previously DIFFICULTY) opcode post-merge state as part of initcode.
+randomOpcodeInit:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x00'
+    currentRandom: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    currentGasLimit: '89128960'
+    currentBaseFee: '10'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: 1000000000
+      code: ''
+      nonce: 0
+      storage: {}
+
+  transaction:
+    data: 
+      - |
+        :yul
+        {
+          // Store all opcodes coming from the block header to verify nothing else is affected.
+          sstore(0, coinbase())
+          sstore(1, timestamp())
+          sstore(2, number())
+          sstore(3, difficulty())
+          sstore(4, gaslimit())
+        }
+    gasLimit:
+      - 70000000
+    gasPrice: 10
+    nonce: 0
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - 0
+
+  expect:
+    - indexes:
+       data: !!int -1
+       gas: !!int -1
+       value: !!int -1
+      network:
+        - '>=London'
+      result:
+       a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          nonce: 1
+       6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          nonce: '0x01'
+          storage:
+            '0': '0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba'
+            '1': '0x3e8'
+            '2': '0x01'
+            '3': '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+            '4': '0x5500000'
+       


### PR DESCRIPTION
Requires: ethereum/retesteth/pull/160

This PR adds state tests for the RANDOM opcode.

Draft only since the required retesteth changes are still not merged.