### PR TITLE
Add state test to check tx sender balance in EIP-1559

### DIFF
--- a/BlockchainTests/GeneralStateTests/stEIP1559/senderBalance.json
+++ b/BlockchainTests/GeneralStateTests/stEIP1559/senderBalance.json
@@ -1,0 +1,242 @@
+{
+    "senderBalance_d0g0v0_London" : {
+        "_info" : {
+            "comment" : "The execution records the EIP-1559 transaction origin balance to make sure its value is \nproperly computed based on the effective gas price (not the maximum gas price as in \nthe transaction validity check).\n",
+            "filling-rpc-server" : "evm version 1.10.21-unstable-692bfd1b-20220630",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.7e597e14.Linux.g++",
+            "generatedTestHash" : "b73b768b1d17d7d8a1785505f77030bf53cffdf77c6cfbe6daca7aa784f2e01c",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.3+commit.8d00100c.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEIP1559/senderBalanceFiller.yml",
+            "sourceHash" : "bc5de911e01ae29396bd8a97fafbba54398ad541af8ad5951ce8d36a88ea2dee"
+        },
+        "blocks" : [
+            {
+                "blockHeader" : {
+                    "baseFeePerGas" : "0x0b",
+                    "bloom" : "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "coinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                    "difficulty" : "0x020000",
+                    "extraData" : "0x00",
+                    "gasLimit" : "0x01c9c380",
+                    "gasUsed" : "0xa8c5",
+                    "hash" : "0x6a94f22359a2a498af062c87ce4c4bd0d746f198af74d93db66f7dc79ceeecbc",
+                    "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "nonce" : "0x0000000000000000",
+                    "number" : "0x01",
+                    "parentHash" : "0xcfcf26f16c6b628390e377ac65bbfd5c58e775c244d7961535d472d191cf1c3a",
+                    "receiptTrie" : "0xdd7d30ffcb3970c3b52102559b042f61c2433f12733298ee88c85643269b23c2",
+                    "stateRoot" : "0x8ee4b197e674a0916984b238120f7ccea0c898b3a6c28b30767795f01e732133",
+                    "timestamp" : "0x03e8",
+                    "transactionsTrie" : "0x8717bd3e9b558bbcb73c8e74daa7c4645d2a6a4382feeb6721464195031a9c8d",
+                    "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                },
+                "rlp" : "0xf90268f901f9a0cfcf26f16c6b628390e377ac65bbfd5c58e775c244d7961535d472d191cf1c3aa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa08ee4b197e674a0916984b238120f7ccea0c898b3a6c28b30767795f01e732133a08717bd3e9b558bbcb73c8e74daa7c4645d2a6a4382feeb6721464195031a9c8da0dd7d30ffcb3970c3b52102559b042f61c2433f12733298ee88c85643269b23c2b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083020000018401c9c38082a8c58203e800a000000000000000000000000000000000000000000000000000000000000000008800000000000000000bf869b86702f8640180648203e882ea6094cccccccccccccccccccccccccccccccccccccccc8080c001a0d7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3a052cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794c0",
+                "transactions" : [
+                    {
+                        "accessList" : [
+                        ],
+                        "chainId" : "0x01",
+                        "data" : "0x",
+                        "gasLimit" : "0xea60",
+                        "maxFeePerGas" : "0x03e8",
+                        "maxPriorityFeePerGas" : "0x64",
+                        "nonce" : "0x00",
+                        "r" : "0xd7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3",
+                        "s" : "0x52cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794",
+                        "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+                        "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+                        "type" : "0x02",
+                        "v" : "0x01",
+                        "value" : "0x00"
+                    }
+                ],
+                "uncleHeaders" : [
+                ]
+            }
+        ],
+        "genesisBlockHeader" : {
+            "baseFeePerGas" : "0x0c",
+            "bloom" : "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "coinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "difficulty" : "0x01",
+            "extraData" : "0x00",
+            "gasLimit" : "0x01c9c380",
+            "gasUsed" : "0x00",
+            "hash" : "0xcfcf26f16c6b628390e377ac65bbfd5c58e775c244d7961535d472d191cf1c3a",
+            "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce" : "0x0000000000000000",
+            "number" : "0x00",
+            "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "stateRoot" : "0xea20be7cf759c060be31f37e6bcbed2489c2d24fe3f59c6c629ff9368ec1c3a9",
+            "timestamp" : "0x00",
+            "transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        },
+        "genesisRLP" : "0xf901f7f901f2a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0ea20be7cf759c060be31f37e6bcbed2489c2d24fe3f59c6c629ff9368ec1c3a9a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001808401c9c380808000a000000000000000000000000000000000000000000000000000000000000000008800000000000000000cc0c0",
+        "lastblockhash" : "0x6a94f22359a2a498af062c87ce4c4bd0d746f198af74d93db66f7dc79ceeecbc",
+        "network" : "London",
+        "postState" : {
+            "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba" : {
+                "balance" : "0x1bc16d674f09ecf4",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0de0b6b3a71ad295",
+                "code" : "0x",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x3331600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0x0de0b6b3a6fe6060"
+                }
+            }
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0de0b6b3a7640000",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x3331600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "sealEngine" : "NoProof"
+    },
+    "senderBalance_d0g0v0_Merge" : {
+        "_info" : {
+            "comment" : "The execution records the EIP-1559 transaction origin balance to make sure its value is \nproperly computed based on the effective gas price (not the maximum gas price as in \nthe transaction validity check).\n",
+            "filling-rpc-server" : "evm version 1.10.21-unstable-692bfd1b-20220630",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.7e597e14.Linux.g++",
+            "generatedTestHash" : "069e70cf71972c49f0459061e66fa705050af9576c3c00081c688ffb1d9cbdc2",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.3+commit.8d00100c.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEIP1559/senderBalanceFiller.yml",
+            "sourceHash" : "bc5de911e01ae29396bd8a97fafbba54398ad541af8ad5951ce8d36a88ea2dee"
+        },
+        "blocks" : [
+            {
+                "blockHeader" : {
+                    "baseFeePerGas" : "0x0b",
+                    "bloom" : "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "coinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                    "difficulty" : "0x00",
+                    "extraData" : "0x00",
+                    "gasLimit" : "0x01c9c380",
+                    "gasUsed" : "0xa8c5",
+                    "hash" : "0xe2643d663244decf3c448cfc97a9296aaf76370c5965e9bf7d11f99dbba4d407",
+                    "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "nonce" : "0x0000000000000000",
+                    "number" : "0x01",
+                    "parentHash" : "0xc7d8e91bad069ed4514f5996f817d149fa2077622ba35d412f5669dac6ede8ae",
+                    "receiptTrie" : "0xdd7d30ffcb3970c3b52102559b042f61c2433f12733298ee88c85643269b23c2",
+                    "stateRoot" : "0xe04af32646c866711a05d0179c8fc2317308c5eabfa0989de15ca69d07bc72f4",
+                    "timestamp" : "0x03e8",
+                    "transactionsTrie" : "0x8717bd3e9b558bbcb73c8e74daa7c4645d2a6a4382feeb6721464195031a9c8d",
+                    "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                },
+                "rlp" : "0xf90265f901f6a0c7d8e91bad069ed4514f5996f817d149fa2077622ba35d412f5669dac6ede8aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0e04af32646c866711a05d0179c8fc2317308c5eabfa0989de15ca69d07bc72f4a08717bd3e9b558bbcb73c8e74daa7c4645d2a6a4382feeb6721464195031a9c8da0dd7d30ffcb3970c3b52102559b042f61c2433f12733298ee88c85643269b23c2b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401c9c38082a8c58203e800a000000000000000000000000000000000000000000000000000000000000000018800000000000000000bf869b86702f8640180648203e882ea6094cccccccccccccccccccccccccccccccccccccccc8080c001a0d7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3a052cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794c0",
+                "transactions" : [
+                    {
+                        "accessList" : [
+                        ],
+                        "chainId" : "0x01",
+                        "data" : "0x",
+                        "gasLimit" : "0xea60",
+                        "maxFeePerGas" : "0x03e8",
+                        "maxPriorityFeePerGas" : "0x64",
+                        "nonce" : "0x00",
+                        "r" : "0xd7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3",
+                        "s" : "0x52cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794",
+                        "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+                        "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+                        "type" : "0x02",
+                        "v" : "0x01",
+                        "value" : "0x00"
+                    }
+                ],
+                "uncleHeaders" : [
+                ]
+            }
+        ],
+        "genesisBlockHeader" : {
+            "baseFeePerGas" : "0x0c",
+            "bloom" : "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "coinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "difficulty" : "0x00",
+            "extraData" : "0x00",
+            "gasLimit" : "0x01c9c380",
+            "gasUsed" : "0x00",
+            "hash" : "0xc7d8e91bad069ed4514f5996f817d149fa2077622ba35d412f5669dac6ede8ae",
+            "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "nonce" : "0x0000000000000000",
+            "number" : "0x00",
+            "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "stateRoot" : "0xea20be7cf759c060be31f37e6bcbed2489c2d24fe3f59c6c629ff9368ec1c3a9",
+            "timestamp" : "0x00",
+            "transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        },
+        "genesisRLP" : "0xf901f7f901f2a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0ea20be7cf759c060be31f37e6bcbed2489c2d24fe3f59c6c629ff9368ec1c3a9a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808401c9c380808000a000000000000000000000000000000000000000000000000000000000000000018800000000000000000cc0c0",
+        "lastblockhash" : "0xe2643d663244decf3c448cfc97a9296aaf76370c5965e9bf7d11f99dbba4d407",
+        "network" : "Merge",
+        "postState" : {
+            "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba" : {
+                "balance" : "0x41ecf4",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0de0b6b3a71ad295",
+                "code" : "0x",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x3331600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0x0de0b6b3a6fe6060"
+                }
+            }
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0de0b6b3a7640000",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x3331600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "sealEngine" : "NoProof"
+    }
+}

--- a/GeneralStateTests/stEIP1559/senderBalance.json
+++ b/GeneralStateTests/stEIP1559/senderBalance.json
@@ -1,0 +1,87 @@
+{
+    "senderBalance" : {
+        "_info" : {
+            "comment" : "The execution records the EIP-1559 transaction origin balance to make sure its value is \nproperly computed based on the effective gas price (not the maximum gas price as in \nthe transaction validity check).\n",
+            "filling-rpc-server" : "evm version 1.10.21-unstable-692bfd1b-20220630",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.7e597e14.Linux.g++",
+            "generatedTestHash" : "722e4ce4aaaff6a59948c3fdddc01cd8a0ba45520037a160dcf12c105173b86d",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.3+commit.8d00100c.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEIP1559/senderBalanceFiller.yml",
+            "sourceHash" : "bc5de911e01ae29396bd8a97fafbba54398ad541af8ad5951ce8d36a88ea2dee"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0b",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x01c9c380",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [
+                {
+                    "hash" : "0xe04af32646c866711a05d0179c8fc2317308c5eabfa0989de15ca69d07bc72f4",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0x02f8640180648203e882ea6094cccccccccccccccccccccccccccccccccccccccc8080c001a0d7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3a052cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794"
+                }
+            ],
+            "Merge" : [
+                {
+                    "hash" : "0xe04af32646c866711a05d0179c8fc2317308c5eabfa0989de15ca69d07bc72f4",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0x02f8640180648203e882ea6094cccccccccccccccccccccccccccccccccccccccc8080c001a0d7c1f4c6e208e7153ffaa09e1d4b5f104d7a999a890531d500cdc3cf753a84e3a052cf8bc07a02a86a2831bef15e099a21d1a646e5f2a5307f7ae53fe1acbd9794"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0de0b6b3a7640000",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x00",
+                "code" : "0x3331600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "accessLists" : [
+                [
+                ]
+            ],
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0xea60"
+            ],
+            "maxFeePerGas" : "0x03e8",
+            "maxPriorityFeePerGas" : "0x64",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEIP1559/senderBalanceFiller.yml
+++ b/src/GeneralStateTestsFiller/stEIP1559/senderBalanceFiller.yml
@@ -1,0 +1,55 @@
+senderBalance:
+  _info:
+    comment: |
+      The execution records the EIP-1559 transaction origin balance to make sure its value is 
+      properly computed based on the effective gas price (not the maximum gas price as in 
+      the transaction validity check).
+
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: 1
+    currentGasLimit: 30000000
+    currentNumber: 1
+    currentTimestamp: 1000
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+    currentBaseFee: 11
+
+  pre:
+    cccccccccccccccccccccccccccccccccccccccc:
+      balance: 0
+      code: |
+        :yul {
+          sstore(0, balance(caller()))
+        }
+      nonce: 0
+      storage: {}
+
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: 1000000000000000000
+      code: ''
+      nonce: 0
+      storage: {}
+
+  transaction:
+    nonce: 0
+    to: cccccccccccccccccccccccccccccccccccccccc
+    value:
+      - 0
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    maxFeePerGas: 1000
+    maxPriorityFeePerGas: 100
+    gasLimit:
+      - 60000
+    data:
+      - data: ''
+        accessList: []
+
+  expect:
+    - indexes:
+        data: !!int -1
+      network:
+        - ">=London"
+      result:
+        cccccccccccccccccccccccccccccccccccccccc:
+          storage:
+            0: 999999999993340000


### PR DESCRIPTION
The execution records the EIP-1559 transaction origin balance to make
sure its value is properly computed based on the effective gas price
(not the maximum gas price as in the transaction validity check).