### PR TITLE
fix JSON format fillers

### DIFF
--- a/src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeOOGInvalidSizeFiller.json
+++ b/src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeOOGInvalidSizeFiller.json
@@ -34,7 +34,7 @@
         },
         "transaction" : {
             "data" : [
-                ":yul {/* code size is 0x600d */ codecopy(0x00, 0x000d, 0x600d) return(0x00, 0x600d) }"
+                ":yul {/* code size is 0x600d */ codecopy(0x00, 0x000d, 0x600d) return(0x00, 0x600d) }",
                 ":yul {/* code size is 0x6001 */ codecopy(0x00, 0x000d, 0x6001) return(0x00, 0x6001) }"
             ],
             "gasLimit" : [

--- a/src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeValidFiller.json
+++ b/src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeValidFiller.json
@@ -34,7 +34,7 @@
         },
         "transaction" : {
             "data" : [
-                ":yul { /* code size is 0x59d5 */ codecopy(0x00, 0x000d, 0x5ed5) return(0x00, 0x5ed5) }"
+                ":yul { /* code size is 0x59d5 */ codecopy(0x00, 0x000d, 0x5ed5) return(0x00, 0x5ed5) }",
                 ":yul { /* code size is 0x6000 - max allowed */ codecopy(0x00, 0x000d, 0x6000) return(0x00, 0x6000) }"
             ],
             "gasLimit" : [

--- a/src/GeneralStateTestsFiller/stPreCompiledContracts/modexpFiller.json
+++ b/src/GeneralStateTestsFiller/stPreCompiledContracts/modexpFiller.json
@@ -280,7 +280,7 @@
 		"29 - exp length 4TiB; returns 0 because mod is zero",
 		"30 - base and mod have zero-length.  exp's length is 2^255.  Since mod is zero, the result should be zero.",
 		"31,32,33,34,35 - something that should result in 1.",
-		"36 - the input found on 10 Oct. 2017 that overflows the gas calculation"
+		"36 - the input found on 10 Oct. 2017 that overflows the gas calculation",
 		"37 - input found in July 2022, overflows the gas calculation"
 	    ],
             "data" : [

--- a/src/GeneralStateTestsFiller/stStaticCall/static_CallContractToCreateContractAndCallItOOGFiller.json
+++ b/src/GeneralStateTestsFiller/stStaticCall/static_CallContractToCreateContractAndCallItOOGFiller.json
@@ -78,7 +78,7 @@
         },
         "transaction" : {
             "data" : [
-                ":raw 0x00"
+                ":raw 0x00",
                 ":raw 0x01"
             ],
             "gasLimit" : [


### PR DESCRIPTION
This PR does the following:
- Fix comma in fillers to be `JSON` compatible
- fillers affected:
  - `src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeOOGInvalidSizeFiller.json`
  - `src/GeneralStateTestsFiller/stCodeSizeLimit/codesizeValidFiller.json`
  - `src/GeneralStateTestsFiller/stPreCompiledContracts/modexpFiller.json`
  - `src/GeneralStateTestsFiller/stStaticCall/static_CallContractToCreateContractAndCallItOOGFiller.json` 