### PR TITLE
Add Gas Leak Test Case

### DIFF
--- a/GeneralStateTests/stBugs/callGasLeak.json
+++ b/GeneralStateTests/stBugs/callGasLeak.json
@@ -1,0 +1,356 @@
+{
+    "callGasLeak" : {
+        "_info" : {
+            "comment" : "Based on https://hackmd.io/@shemnon/besu-gas-leak",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-83e6e04c",
+            "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.55a9ee2d.Linux.g++",
+            "generatedTestHash" : "25ef4a472b00786bd370251d20c79b6cbc15a1991f536c60f7ab8cd133c03a59",
+            "labels" : {
+                "0" : "ok",
+                "1" : "ok",
+                "10" : "ok",
+                "11" : "ok",
+                "12" : "ok",
+                "13" : "ok",
+                "14" : "ok",
+                "15" : "ok",
+                "16" : "ok",
+                "17" : "ok",
+                "18" : "ok",
+                "19" : "ok",
+                "2" : "ok",
+                "20" : "ok",
+                "21" : "ok",
+                "22" : "ok",
+                "23" : "ok",
+                "3" : "ok",
+                "4" : "ok",
+                "5" : "ok",
+                "6" : "ok",
+                "7" : "ok",
+                "8" : "ok",
+                "9" : "ok"
+            },
+            "lllcversion" : "Version: 0.5.14-develop.2021.10.5+commit.401d5358.Linux.g++",
+            "solidity" : "Version: 0.8.5+commit.a4f2e591.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stBugs/callGasLeakFiller.yml",
+            "sourceHash" : "43345a1e45348e6a2d88a7b41395976de9f85bde8f44a0525f47448623cd3f90"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05f5e100",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000020000",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [
+                {
+                    "hash" : "0xabc6abde236a421bd1db5aabc45301dd47e1b92f60c81a6b7c12f73315080ea8",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffffffffffff1ca01f14c002cf49812711da434947144dee70a9e622752c8b04c082a79adc347b44a016d9d50a5730d69c590945968b6627d75f615a38411bcd43ffd74d0d73d1b861"
+                },
+                {
+                    "hash" : "0x5133bb9cf018ffebe751a4c75748e622bbdc3728e7c3d621f4c68abdff125ece",
+                    "indexes" : {
+                        "data" : 1,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000001ba0b74937bdc5c2a64f2a639a0a5120fd69b32249e2387c9d083a71cffbb7212a33a05d0da0ab18620610120d400b03b652d2a6055a1a0771ff44b258efcbbdc85c7e"
+                },
+                {
+                    "hash" : "0x9cdd71ce9ac4dff8cb9800e768a9d255ad5af1ba5737a9865f77a50af8e1cde3",
+                    "indexes" : {
+                        "data" : 2,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000011ba0a43af96c98cc59cad9e51f62a5fe5d964e878288d495f63920cdfda75233a8efa009a0608aef984036886eb243b171b00ced40541f7dad1b0757068a0e36ce16b2"
+                },
+                {
+                    "hash" : "0xabc6abde236a421bd1db5aabc45301dd47e1b92f60c81a6b7c12f73315080ea8",
+                    "indexes" : {
+                        "data" : 3,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008fffffffffffffff1ba0dfa33881a8e591a918559fda62899e86a2ea94bb63a2f4c4f439d09a10d5a62fa01aaaba08e5e24a6d908e3f3983dfe2d2be954e7398104ac0cc5a8d33b00f13c4"
+                },
+                {
+                    "hash" : "0xabc6abde236a421bd1db5aabc45301dd47e1b92f60c81a6b7c12f73315080ea8",
+                    "indexes" : {
+                        "data" : 4,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffff1ca0dab8d5f38bd3a99183cd7b56da9c66f12d9a77adf3fae92744bcaac5d0fed6cfa06f7f263578059b2617ce92b5b26d8657f714781daa0c6156b132e4e0153f5455"
+                },
+                {
+                    "hash" : "0x5133bb9cf018ffebe751a4c75748e622bbdc3728e7c3d621f4c68abdff125ece",
+                    "indexes" : {
+                        "data" : 5,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000001ca0a5d24fad238d155d74844d4b72d3728a1c399690bf7906c2c500b7b675bbdb70a07d683e7df0a25a710e653fb3a05cb26d621c3a0adf45200a89d5813964a6d882"
+                },
+                {
+                    "hash" : "0xfc7efec5ddcb639db368df28617796bd2d34ba4fe014de671312eb186c30b7ef",
+                    "indexes" : {
+                        "data" : 6,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000007fffffffffffffff1ba07830b872e0a2de393eaebad187aa429a38fce5030e445ac478f212294a934f88a006538fec47ab22ddfd491c6f04dfb446b1a5c4540c512462ad431cb14caf897c"
+                },
+                {
+                    "hash" : "0xb05c022e57f7f24c320463d44e26fce407a77eea1bf3a2c7e839fffa114675d5",
+                    "indexes" : {
+                        "data" : 7,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000080000000000000001ca0aa53cb9628f582f288437d09a60224786c52fd03748e5c192ca5ce016aa3e956a04071a0253f7fb722e99dfedc8d6ef87a746d546ae856a89f5e20f5389fb90d54"
+                },
+                {
+                    "hash" : "0x84eea3b91e76516aa7f897a0573388437f4eaf6f034f9cd2e915b29d02039930",
+                    "indexes" : {
+                        "data" : 8,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000080000000000000011ba0feca79441199ecab4223d4d0da39fc08ce951c28e4693d9829fe4068c0b91edaa02b0c149e73839e340da531881b671c65b18bbc60e53f1477159a63d8ccd16ef4"
+                },
+                {
+                    "hash" : "0xfc7efec5ddcb639db368df28617796bd2d34ba4fe014de671312eb186c30b7ef",
+                    "indexes" : {
+                        "data" : 9,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000008fffffffffffffff1ba06f5e8be0c142df1ba510a2ec2a8de95469696c514eb29e60dff403ae6439a6f1a02684358718d2a0158e28b1d5723d9ec1165e6df1eeb1476d13e8ce658feed890"
+                },
+                {
+                    "hash" : "0xfc7efec5ddcb639db368df28617796bd2d34ba4fe014de671312eb186c30b7ef",
+                    "indexes" : {
+                        "data" : 10,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000ffffffffffffffff1ba0129834335f8a04192c7aa4491a6945e62ffe9f2144a89886cb1e6505f4a05da6a04a0b49630b5c8769ae297a95c3e71ad6ea89c7d5ed6015e5bab40ee1a2668481"
+                },
+                {
+                    "hash" : "0xb05c022e57f7f24c320463d44e26fce407a77eea1bf3a2c7e839fffa114675d5",
+                    "indexes" : {
+                        "data" : 11,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000100000000000000001ca01a0cc441baaea741980e93bbd4eb120142150e3a2563de4d2a572ed096eb7e94a07f9b96cbc7b69d53320f4edebcce81c347d68f12e419fd07e61270d528b6d156"
+                },
+                {
+                    "hash" : "0xe3ba40ddf6292a3f4105eb174a0830b6b33d92906b3c8f4145d5ef530990669c",
+                    "indexes" : {
+                        "data" : 12,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000007fffffffffffffff1ba0d21120f06fbe2e0ec2e077489d856c52ec5756ed23eab32f09e612c297528883a008547c7ad010e91c0478c0001c9999e65fb2a67d0d7d46b8a71cfe8e67e5a307"
+                },
+                {
+                    "hash" : "0xe273d00c0f37596a9966d5af7eb0d2d6c6942b767c6e91b42776efd22c994e1f",
+                    "indexes" : {
+                        "data" : 13,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000080000000000000001ba04b625f2d44e8a51d88aef068c73150c5bcf18e58cc4de836f8c53ae901b3aa36a05fef8fe84dde0b525b8114714bf4948cc700d05ff57a32e61d2610debd433338"
+                },
+                {
+                    "hash" : "0x1a7cc999d5933034c96d8d25b590055b1385a42153625217f3e7afcf6eb41aa0",
+                    "indexes" : {
+                        "data" : 14,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000080000000000000011ca0260c5251945677765adc51b400a4acada3246ec81f97abf0b2d1e90d1a4cf7e4a0128c4abaa48e149f27b2417486511a686932536cca5399e3c49d1836b5a9d9bd"
+                },
+                {
+                    "hash" : "0xe3ba40ddf6292a3f4105eb174a0830b6b33d92906b3c8f4145d5ef530990669c",
+                    "indexes" : {
+                        "data" : 15,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000008fffffffffffffff1ca0d5cc6051cb4b612d38b6ed70b3f7c7df8e9bc8a0c52a1a7cade2092e869c9c40a013bb54462a408ac774e09d13d5807519037dd04d50ab864ed8eaa468bc43414c"
+                },
+                {
+                    "hash" : "0xe3ba40ddf6292a3f4105eb174a0830b6b33d92906b3c8f4145d5ef530990669c",
+                    "indexes" : {
+                        "data" : 16,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e60000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000ffffffffffffffff1ca0db277070e70bc5195c979aaa27e8090c927c89653e3304b0911f0a92e749b55ba0335f63759e59ceff1308e1965e840d0c89d037de71e1854cbc36ee1ae55bbc4e"
+                },
+                {
+                    "hash" : "0xe273d00c0f37596a9966d5af7eb0d2d6c6942b767c6e91b42776efd22c994e1f",
+                    "indexes" : {
+                        "data" : 17,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000100000000000000001ca00da06015baf0e015dba5b38874983e308aaabad5f4c55068068c55557d33d221a048c3ce5b9a278d4da93141be1894432470c3bc67ba7d68e5a16279f5aac41674"
+                },
+                {
+                    "hash" : "0x212964bb343cf52cd0c1196f85b3fbf40f5986e0a5a585c1823eac90ec6969c5",
+                    "indexes" : {
+                        "data" : 18,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000007fffffffffffffff1ca0b6b8b5ce0ccf13b6d0d2bea2ff625fe61e2d99f62d481c5fb8d1b3e1ffa39490a0174ac9322dc8bc2d93aa2a5494a1855b7199d2fdbcd851be6d69fdfb6b5c8946"
+                },
+                {
+                    "hash" : "0x88f51538bfb3f25a6cfecfffa01ebdc7d2127bf61c43a049c5c2809db7802cb4",
+                    "indexes" : {
+                        "data" : 19,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000080000000000000001ca04504ea88abd5e09cf11189038f350f68ff4f1051fb15a83bfcffb37cc35bf8f3a03851f4ece072281cc5a7b6308bfd7ebfcb82c92460ba577eea4303c447d50909"
+                },
+                {
+                    "hash" : "0x6a152bb5ac613f6739bba27c7b8d4e1912ff36c875487c75b14095a7becde1f5",
+                    "indexes" : {
+                        "data" : 20,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000080000000000000011ba0ae820fb6ef6d3e0f57eef9851d7283ba7e2fd4e417743c4e6a1c081ea92dd158a0691aa92d29ea75b1d3e86fb9192eddb83741f9e7896f1b9ae74fa26ba0e2a821"
+                },
+                {
+                    "hash" : "0x212964bb343cf52cd0c1196f85b3fbf40f5986e0a5a585c1823eac90ec6969c5",
+                    "indexes" : {
+                        "data" : 21,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000008fffffffffffffff1ca0f86eeb41f0ef1624fc84c2ca99f89e46016f14eb987a149e6bac28822bfe635fa06ad08175bea1a84b1a034c043ab35dcca9607f0e802f2e0e0c753556a5ce3654"
+                },
+                {
+                    "hash" : "0x212964bb343cf52cd0c1196f85b3fbf40f5986e0a5a585c1823eac90ec6969c5",
+                    "indexes" : {
+                        "data" : 22,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e60000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000ffffffffffffffff1ba0d3f59639e7f2bfaaf1fd781fa6307f66882e64669a2efa7831ff9c679bf1c89ba045156df356d71a6021ae26942086cf6170958f01e38a9c90d9f60ff9084ec7a9"
+                },
+                {
+                    "hash" : "0x88f51538bfb3f25a6cfecfffa01ebdc7d2127bf61c43a049c5c2809db7802cb4",
+                    "indexes" : {
+                        "data" : 23,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf8a5010a837a120094cccccccccccccccccccccccccccccccccccccccc80b8441a8451e6000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000100000000000000001ba03a3c5d7e04a5b1adb8ec7d15c63402fdce65492e9c2128ad0e6a7f16ce3dc5dca07fa1a77ed293d329d9403bba704fa1597c0262cb54d374d810301e1150e5459d"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x00",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x60043560243573bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb5a8360008114603c5760018114604e576002811460605760038114607057607d565b600060006000600060008789f150607d565b600060006000600060008789f250607d565b60006000600060008688f450607d565b60006000600060008688fa505b50805a1115608b5760016001555b600160005550505050",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000001",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008fffffffffffffff",
+                "0x1a8451e60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000007fffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000008000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000008000000000000001",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000008fffffffffffffff",
+                "0x1a8451e60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000ffffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000010000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000007fffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000008000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000008000000000000001",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000008fffffffffffffff",
+                "0x1a8451e60000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000ffffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000010000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000007fffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000008000000000000000",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000008000000000000001",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000008fffffffffffffff",
+                "0x1a8451e60000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000ffffffffffffffff",
+                "0x1a8451e600000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000010000000000000000"
+            ],
+            "gasLimit" : [
+                "0x7a1200"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x01",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stBugs/callGasLeakFiller.yml
+++ b/src/GeneralStateTestsFiller/stBugs/callGasLeakFiller.yml
@@ -1,0 +1,112 @@
+# Ensure the correct gas is returned after call operation using different values
+# as gas parameter
+
+callGasLeak:
+
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x20000'
+    currentGasLimit: "100000000"
+    currentNumber: "1"
+    currentTimestamp: "1000"
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+
+  _info:
+    comment: Based on https://hackmd.io/@shemnon/besu-gas-leak
+
+
+  pre:
+
+
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:
+      balance: '0x0ba1a9ce0ba1a9ce'
+      code: '0x00'
+      nonce: 1
+      storage: {}
+
+    # Main stack frame should not run out of gas:
+    # on besu, a gas value between 2^64-1 and 2^63-1 was incorrectly interpreted
+    # as a negative number, then added to the remaining gas of the calling stack.
+    # Gas should also not increase after the call.
+    cccccccccccccccccccccccccccccccccccccccc:
+      balance: '0x0ba1a9ce0ba1a9ce'
+      code: |
+       :yul {
+         let calltype  := calldataload(0x04)
+         let gasAmount := calldataload(0x24)
+         let callAddr  := 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+         let prevGas := gas()
+
+         switch calltype
+         case 0 { pop(call(gasAmount, callAddr, 0, 0, 0, 0, 0)) }
+         case 1 { pop(callcode(gasAmount, callAddr, 0, 0, 0, 0, 0)) }
+         case 2 { pop(delegatecall(gasAmount, callAddr, 0, 0, 0, 0)) }
+         case 3 { pop(staticcall(gasAmount, callAddr, 0, 0, 0, 0)) }
+         
+         /* If the remaining gas increased, or we ran out of gas, test fails */
+         if gt(gas(), prevGas) { sstore (1, 1) }
+         sstore (0, 1)
+       }        
+      nonce: 1
+      storage: {}
+
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '0x0ba1a9ce0ba1a9ce'
+      code: 0x
+      nonce: 1
+      storage: {}
+
+
+  transaction:
+    data:
+    # Test all limit values around 2**63 and 2**64.
+    # CALL
+    - :label ok :abi f(uint,uint) 0 0x7fffffffffffffff
+    - :label ok :abi f(uint,uint) 0 0x8000000000000000
+    - :label ok :abi f(uint,uint) 0 0x8000000000000001
+    - :label ok :abi f(uint,uint) 0 0x8fffffffffffffff
+    - :label ok :abi f(uint,uint) 0 0xffffffffffffffff
+    - :label ok :abi f(uint,uint) 0 0x10000000000000000
+    # CALLCODE
+    - :label ok :abi f(uint,uint) 1 0x7fffffffffffffff
+    - :label ok :abi f(uint,uint) 1 0x8000000000000000
+    - :label ok :abi f(uint,uint) 1 0x8000000000000001
+    - :label ok :abi f(uint,uint) 1 0x8fffffffffffffff
+    - :label ok :abi f(uint,uint) 1 0xffffffffffffffff
+    - :label ok :abi f(uint,uint) 1 0x10000000000000000
+    # DELEGATECALL
+    - :label ok :abi f(uint,uint) 2 0x7fffffffffffffff
+    - :label ok :abi f(uint,uint) 2 0x8000000000000000
+    - :label ok :abi f(uint,uint) 2 0x8000000000000001
+    - :label ok :abi f(uint,uint) 2 0x8fffffffffffffff
+    - :label ok :abi f(uint,uint) 2 0xffffffffffffffff
+    - :label ok :abi f(uint,uint) 2 0x10000000000000000
+    # STATICCALL
+    - :label ok :abi f(uint,uint) 3 0x7fffffffffffffff
+    - :label ok :abi f(uint,uint) 3 0x8000000000000000
+    - :label ok :abi f(uint,uint) 3 0x8000000000000001
+    - :label ok :abi f(uint,uint) 3 0x8fffffffffffffff
+    - :label ok :abi f(uint,uint) 3 0xffffffffffffffff
+    - :label ok :abi f(uint,uint) 3 0x10000000000000000
+
+    gasLimit:
+    - 8000000
+    gasPrice: 10
+    nonce: 1
+    to: cccccccccccccccccccccccccccccccccccccccc
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    value:
+    - 0
+
+  expect:
+    - indexes:
+        data: 
+        - :label ok
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - 'London'
+      result:
+        cccccccccccccccccccccccccccccccccccccccc:
+          storage:
+            0: 1


### PR DESCRIPTION
Introduces test to verify a Besu consensus issue described here: https://hackmd.io/@shemnon/besu-gas-leak

Test will use call opcodes with gas values in edge values around `2**63` and `2**64` and verify that the EVM does not run out of gas (due to improper subtraction of the remaining gas) or has more remaining gas than before the call.

Verified using besu evmtool versions: [22.7.3](https://hub.docker.com/layers/hyperledger/besu-evmtool/22.7.3/images/sha256-ff70ba4f485c477f3a19654ba1c6fbc8766b21e5c01cf33c2b26957157b5f09d?context=explore) and [22.7.0-RC3](https://hub.docker.com/layers/hyperledger/besu-evmtool/22.7.0-RC3/images/sha256-509da9443ccb0de6387a3525d53b8cb6c36e96a2098c2292a898912ddd7e3e7a?context=explore), test fails on 22.7.0-RC3, and passes on 22.7.3.

Implements #1083 