### PR TITLE
EIP-3860: Update tests for CREATE/CREATE2 according to spec change

### DIFF
--- a/BlockchainTests/GeneralStateTests/stEIP3860/create2InitCodeSizeLimit.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3860/create2InitCodeSizeLimit.json
@@ -2,13 +2,13 @@
     "create2InitCodeSizeLimit_d0g0v0_Merge" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "31ea20b965e8f865c97f414f142c6b13af9e47bb56bc67e04788ef8e83780888",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml",
-            "sourceHash" : "bbdf711aad58bc3ca6266f7508440c279e72d5077c6006f3b89e0e8871fa5d8c"
+            "sourceHash" : "46d699ada12059f561e441a99ce80e3e3ccfff38c5723087b065ad4728163cef"
         },
         "blocks" : [
             {
@@ -119,13 +119,13 @@
     "create2InitCodeSizeLimit_d0g0v0_Merge+3860" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "8660d88ee24f8aa0e301f1e0823e0ad0fa6e563c1f0ccb00177e095eb38a0cef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml",
-            "sourceHash" : "bbdf711aad58bc3ca6266f7508440c279e72d5077c6006f3b89e0e8871fa5d8c"
+            "sourceHash" : "46d699ada12059f561e441a99ce80e3e3ccfff38c5723087b065ad4728163cef"
         },
         "blocks" : [
             {
@@ -236,13 +236,13 @@
     "create2InitCodeSizeLimit_d1g0v0_Merge" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "64f17ec953348fff20b7f644aa910cd0035304132e6f74062a921de34511934f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml",
-            "sourceHash" : "bbdf711aad58bc3ca6266f7508440c279e72d5077c6006f3b89e0e8871fa5d8c"
+            "sourceHash" : "46d699ada12059f561e441a99ce80e3e3ccfff38c5723087b065ad4728163cef"
         },
         "blocks" : [
             {
@@ -353,13 +353,13 @@
     "create2InitCodeSizeLimit_d1g0v0_Merge+3860" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
-            "generatedTestHash" : "cd093d9f1c9a9911cbb99268af15ce5606220eefc34d8c27ecad0ef5cb2c7f97",
+            "generatedTestHash" : "2d544613d35f86d6f79315140425f8f2d229c369f65679a0e82822950ca0e078",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml",
-            "sourceHash" : "bbdf711aad58bc3ca6266f7508440c279e72d5077c6006f3b89e0e8871fa5d8c"
+            "sourceHash" : "46d699ada12059f561e441a99ce80e3e3ccfff38c5723087b065ad4728163cef"
         },
         "blocks" : [
             {
@@ -370,19 +370,19 @@
                     "difficulty" : "0x00",
                     "extraData" : "0x00",
                     "gasLimit" : "0x01312d00",
-                    "gasUsed" : "0x01d92b",
-                    "hash" : "0x3ccaafb7562fd9202cffa04ee9e9ae37f86a27717100f375072f2e4d07c8c650",
+                    "gasUsed" : "0x01cd29",
+                    "hash" : "0xd02ee08f356d2e585b574ac75cd74dc6122c2cb062b94d1c8ee087e2d6db0cf5",
                     "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000020000",
                     "nonce" : "0x0000000000000000",
                     "number" : "0x01",
                     "parentHash" : "0x966aaefa9c36325a498db35d3d2829daabab8a98803ee154543e6fa57a44be0f",
-                    "receiptTrie" : "0xa0d62f24cedc7beb42d11565b3a5a279da0edae5fcc09be83b281a21423963f3",
-                    "stateRoot" : "0x46dca2d3f7dc62c6262488db7a65f3a10851748b9f530d79f573077b2fcc4890",
+                    "receiptTrie" : "0xa1cac0b5a9aac3f45690eb2c44b8af561ab6a43f4f055487351ef870894df9c9",
+                    "stateRoot" : "0xdbb3e4a20d8e96a0d8bcdcc315ce1731902c388919ad063dff8f5e883b95af83",
                     "timestamp" : "0x03e8",
                     "transactionsTrie" : "0x56be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286d",
                     "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
                 },
-                "rlp" : "0xf9027ff901f7a0966aaefa9c36325a498db35d3d2829daabab8a98803ee154543e6fa57a44be0fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa046dca2d3f7dc62c6262488db7a65f3a10851748b9f530d79f573077b2fcc4890a056be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286da0a0d62f24cedc7beb42d11565b3a5a279da0edae5fcc09be83b281a21423963f3b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401312d008301d92b8203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000af882f880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0011ca0fa5e0f7c53cba5169bd5b239b479ba8668cf69d8c06d24b00a585b995a1c2c67a056382ddd27880d6393b3f905dc75db8a0c30eeb1c9a8443ac53723ca4feba37cc0",
+                "rlp" : "0xf9027ff901f7a0966aaefa9c36325a498db35d3d2829daabab8a98803ee154543e6fa57a44be0fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0dbb3e4a20d8e96a0d8bcdcc315ce1731902c388919ad063dff8f5e883b95af83a056be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286da0a1cac0b5a9aac3f45690eb2c44b8af561ab6a43f4f055487351ef870894df9c9b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401312d008301cd298203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000af882f880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0011ca0fa5e0f7c53cba5169bd5b239b479ba8668cf69d8c06d24b00a585b995a1c2c67a056382ddd27880d6393b3f905dc75db8a0c30eeb1c9a8443ac53723ca4feba37cc0",
                 "transactions" : [
                     {
                         "data" : "0x000000000000000000000000000000000000000000000000000000000000c001",
@@ -421,11 +421,11 @@
             "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
         },
         "genesisRLP" : "0xf901f7f901f2a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa00608d0d97736b282ea0d9310d51260d922e33916941ec076f294bfb43c4c7b46a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808401312d00808000a000000000000000000000000000000000000000000000000000000000000200008800000000000000000bc0c0",
-        "lastblockhash" : "0x3ccaafb7562fd9202cffa04ee9e9ae37f86a27717100f375072f2e4d07c8c650",
+        "lastblockhash" : "0xd02ee08f356d2e585b574ac75cd74dc6122c2cb062b94d1c8ee087e2d6db0cf5",
         "network" : "Merge+3860",
         "postState" : {
             "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
-                "balance" : "0x0bd94652",
+                "balance" : "0x0bd9be66",
                 "code" : "0x",
                 "nonce" : "0x01",
                 "storage" : {
@@ -434,10 +434,10 @@
             "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0x00",
                 "code" : "0x7f600a80600080396000f3000000000000000000000000000000000000000000006000526000355a600082600080f55a8203600a558060005560018055505050",
-                "nonce" : "0x01",
+                "nonce" : "0x00",
                 "storage" : {
                     "0x01" : "0x01",
-                    "0x0a" : "0xd11c"
+                    "0x0a" : "0xc51a"
                 }
             }
         },

--- a/BlockchainTests/GeneralStateTests/stEIP3860/createInitCodeSizeLimit.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3860/createInitCodeSizeLimit.json
@@ -2,13 +2,13 @@
     "createInitCodeSizeLimit_d0g0v0_Merge" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "1552d2657306847721e671c096c7fa043ba005fa85340c8726dd2c4fe5f0660d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml",
-            "sourceHash" : "166699a98f634ae792035ae345b45e6e383522f98890defe1b61da9f5b7d191f"
+            "sourceHash" : "861b77bf26c2f94a76086292fe35ee5fb4f9fb037e1c2caaccfb8a78ffc4bbbe"
         },
         "blocks" : [
             {
@@ -119,13 +119,13 @@
     "createInitCodeSizeLimit_d0g0v0_Merge+3860" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "91226fcc4ee11b72fa934b6b85e9fd8d922f6353348f4af0630fc0fd7568da24",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml",
-            "sourceHash" : "166699a98f634ae792035ae345b45e6e383522f98890defe1b61da9f5b7d191f"
+            "sourceHash" : "861b77bf26c2f94a76086292fe35ee5fb4f9fb037e1c2caaccfb8a78ffc4bbbe"
         },
         "blocks" : [
             {
@@ -236,13 +236,13 @@
     "createInitCodeSizeLimit_d1g0v0_Merge" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
             "generatedTestHash" : "5ab853a8b8cf36e7e5904516c32f94ffb2d96e39b19dfb1ad5b7a4924f68bde0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml",
-            "sourceHash" : "166699a98f634ae792035ae345b45e6e383522f98890defe1b61da9f5b7d191f"
+            "sourceHash" : "861b77bf26c2f94a76086292fe35ee5fb4f9fb037e1c2caaccfb8a78ffc4bbbe"
         },
         "blocks" : [
             {
@@ -353,13 +353,13 @@
     "createInitCodeSizeLimit_d1g0v0_Merge+3860" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-1d6e96f2-20221124",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
-            "generatedTestHash" : "1a745f5dc9cf6999067fd349b5b6204962ff975b2d71dae5ff3c9f03da98afe7",
+            "generatedTestHash" : "f35e78673de8aa0d17edf01b64f84a35c716077363b744b320dbacabd6caced7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml",
-            "sourceHash" : "166699a98f634ae792035ae345b45e6e383522f98890defe1b61da9f5b7d191f"
+            "sourceHash" : "861b77bf26c2f94a76086292fe35ee5fb4f9fb037e1c2caaccfb8a78ffc4bbbe"
         },
         "blocks" : [
             {
@@ -370,19 +370,19 @@
                     "difficulty" : "0x00",
                     "extraData" : "0x00",
                     "gasLimit" : "0x01312d00",
-                    "gasUsed" : "0x01b522",
-                    "hash" : "0xeeb2e1cf0849dc0b7b3651ae1fd60b6f62ae6444d7e38632d26341a383aeed2d",
+                    "gasUsed" : "0x01a920",
+                    "hash" : "0xc4e7de945ffcdfbc96d59add05cf7906849fa31dbbcc2c862d04a63a5ecdee0e",
                     "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000020000",
                     "nonce" : "0x0000000000000000",
                     "number" : "0x01",
                     "parentHash" : "0x4c91c04e391d8de126f7ed9cff62f5af347efbc4ee01f6d6457cdaf5490a387f",
-                    "receiptTrie" : "0x0d2a6d79728ab10706fb9b14d9affb09950cfcca62e6a06eb67be54579d0cec9",
-                    "stateRoot" : "0x318c8bb6725dee48041bfb137a23af54688b9ef798cb2cf85f03a5bc698d68c2",
+                    "receiptTrie" : "0x2b6312c54d642572dda56de4bce67aee5eb2aff16e7006b254d47f1d85169a12",
+                    "stateRoot" : "0x96efede720d48405f640c41837a8da4775e970271046b2bfa00a2491572775f4",
                     "timestamp" : "0x03e8",
                     "transactionsTrie" : "0x56be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286d",
                     "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
                 },
-                "rlp" : "0xf9027ff901f7a04c91c04e391d8de126f7ed9cff62f5af347efbc4ee01f6d6457cdaf5490a387fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0318c8bb6725dee48041bfb137a23af54688b9ef798cb2cf85f03a5bc698d68c2a056be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286da00d2a6d79728ab10706fb9b14d9affb09950cfcca62e6a06eb67be54579d0cec9b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401312d008301b5228203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000af882f880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0011ca0fa5e0f7c53cba5169bd5b239b479ba8668cf69d8c06d24b00a585b995a1c2c67a056382ddd27880d6393b3f905dc75db8a0c30eeb1c9a8443ac53723ca4feba37cc0",
+                "rlp" : "0xf9027ff901f7a04c91c04e391d8de126f7ed9cff62f5af347efbc4ee01f6d6457cdaf5490a387fa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa096efede720d48405f640c41837a8da4775e970271046b2bfa00a2491572775f4a056be989ed075134aa66853f96e2880be22e77028f88e3df8cd67d7a01a8d286da02b6312c54d642572dda56de4bce67aee5eb2aff16e7006b254d47f1d85169a12b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018401312d008301a9208203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000af882f880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0011ca0fa5e0f7c53cba5169bd5b239b479ba8668cf69d8c06d24b00a585b995a1c2c67a056382ddd27880d6393b3f905dc75db8a0c30eeb1c9a8443ac53723ca4feba37cc0",
                 "transactions" : [
                     {
                         "data" : "0x000000000000000000000000000000000000000000000000000000000000c001",
@@ -421,11 +421,11 @@
             "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
         },
         "genesisRLP" : "0xf901f7f901f2a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa00fc8ca149921741965d0ec0087f30f84ea9db8c0497a17f48247d21ab6e9c1baa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808401312d00808000a000000000000000000000000000000000000000000000000000000000000200008800000000000000000bc0c0",
-        "lastblockhash" : "0xeeb2e1cf0849dc0b7b3651ae1fd60b6f62ae6444d7e38632d26341a383aeed2d",
+        "lastblockhash" : "0xc4e7de945ffcdfbc96d59add05cf7906849fa31dbbcc2c862d04a63a5ecdee0e",
         "network" : "Merge+3860",
         "postState" : {
             "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
-                "balance" : "0x0bdaaeac",
+                "balance" : "0x0bdb26c0",
                 "code" : "0x",
                 "nonce" : "0x01",
                 "storage" : {
@@ -434,10 +434,10 @@
             "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0x00",
                 "code" : "0x7f600a80600080396000f3000000000000000000000000000000000000000000006000526000355a81600080f05a8203600a558060005560018055505050",
-                "nonce" : "0x01",
+                "nonce" : "0x00",
                 "storage" : {
                     "0x01" : "0x01",
-                    "0x0a" : "0xad13"
+                    "0x0a" : "0xa111"
                 }
             }
         },

--- a/GeneralStateTests/stEIP3860/create2InitCodeSizeLimit.json
+++ b/GeneralStateTests/stEIP3860/create2InitCodeSizeLimit.json
@@ -2,9 +2,9 @@
     "create2InitCodeSizeLimit" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-8b819aea-20221123",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
-            "generatedTestHash" : "d9d5365a2c781ab26671cfac3d8a48d852fb6aa7e14b60566b86bd913d3b5615",
+            "generatedTestHash" : "fe9d6d1cf77b75d85877453a642f3736c5f30c7fa43085fd8a220a8390bcfdc2",
             "labels" : {
                 "0" : "valid",
                 "1" : "invalid"
@@ -12,7 +12,7 @@
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml",
-            "sourceHash" : "bbdf711aad58bc3ca6266f7508440c279e72d5077c6006f3b89e0e8871fa5d8c"
+            "sourceHash" : "46d699ada12059f561e441a99ce80e3e3ccfff38c5723087b065ad4728163cef"
         },
         "env" : {
             "currentBaseFee" : "0x0a",
@@ -59,7 +59,7 @@
                     "txbytes" : "0xf880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0001ba0110f52aeb16c3e91943160d2e89c416b06dc47c7484a882324c6d0d362a26cd0a0774c7a35a3503be3867e7bb56885a9056ab1b7e5bfad19b1b0a3550d49a89d6f"
                 },
                 {
-                    "hash" : "0x46dca2d3f7dc62c6262488db7a65f3a10851748b9f530d79f573077b2fcc4890",
+                    "hash" : "0xdbb3e4a20d8e96a0d8bcdcc315ce1731902c388919ad063dff8f5e883b95af83",
                     "indexes" : {
                         "data" : 1,
                         "gas" : 0,

--- a/GeneralStateTests/stEIP3860/createInitCodeSizeLimit.json
+++ b/GeneralStateTests/stEIP3860/createInitCodeSizeLimit.json
@@ -2,9 +2,9 @@
     "createInitCodeSizeLimit" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.11.0-unstable-f4542605-20221109",
+            "filling-rpc-server" : "evm version 1.11.0-unstable-8b819aea-20221123",
             "filling-tool-version" : "retesteth-0.2.3-postmerge+commit.1de2b4bd.Linux.g++",
-            "generatedTestHash" : "4f37573384dee7c1c015e32dd7b260405c83cae49a615fced19c5e7ee48a69ae",
+            "generatedTestHash" : "b330c887912eb92c0e69dea6f127cbe8aa6910eba091355d21070b2c1db518e5",
             "labels" : {
                 "0" : "valid",
                 "1" : "invalid"
@@ -12,7 +12,7 @@
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
             "source" : "src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml",
-            "sourceHash" : "166699a98f634ae792035ae345b45e6e383522f98890defe1b61da9f5b7d191f"
+            "sourceHash" : "861b77bf26c2f94a76086292fe35ee5fb4f9fb037e1c2caaccfb8a78ffc4bbbe"
         },
         "env" : {
             "currentBaseFee" : "0x0a",
@@ -59,7 +59,7 @@
                     "txbytes" : "0xf880800a83e4e1c094b94f5374fce5edbc8e2a8697c15331677e6ebf0b80a0000000000000000000000000000000000000000000000000000000000000c0001ba0110f52aeb16c3e91943160d2e89c416b06dc47c7484a882324c6d0d362a26cd0a0774c7a35a3503be3867e7bb56885a9056ab1b7e5bfad19b1b0a3550d49a89d6f"
                 },
                 {
-                    "hash" : "0x318c8bb6725dee48041bfb137a23af54688b9ef798cb2cf85f03a5bc698d68c2",
+                    "hash" : "0x96efede720d48405f640c41837a8da4775e970271046b2bfa00a2491572775f4",
                     "indexes" : {
                         "data" : 1,
                         "gas" : 0,

--- a/src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml
+++ b/src/GeneralStateTestsFiller/stEIP3860/create2InitCodeSizeLimitFiller.yml
@@ -112,9 +112,10 @@ create2InitCodeSizeLimit:
        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
           nonce: 1
        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          nonce: 0
           storage:
               '0': 0
               '1': 1
-              '10': 53532
+              '10': 50458
        094147686c565aa7ccac18000c3b7b4d099f92d3:
           shouldnotexist: 1

--- a/src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml
+++ b/src/GeneralStateTestsFiller/stEIP3860/createInitCodeSizeLimitFiller.yml
@@ -112,9 +112,10 @@ createInitCodeSizeLimit:
        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
           nonce: 1
        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          nonce: 0
           storage:
               '0': 0
               '1': 1
-              '10': 44307
+              '10': 41233
        f1ecf98489fa9ed60a664fc4998db699cfa39d40:
           shouldnotexist: 1


### PR DESCRIPTION
The spec was clarified and geth implementation changed:
1. Nonce is not incremented when CREATE/CREATE2 fails due to initcode size above limit
2. Initcode charge is not deducted when CREATE/CREATE2 fails due to initcode size above limit

https://github.com/ethereum/EIPs/pull/6040
https://github.com/ethereum/go-ethereum/pull/23847