### PR TITLE
fix source stEIP3540

### DIFF
--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "4bfca2cd50435705565615ca8bc989f8e760bdf9103698ec36c6c2061ae19a39",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -128,7 +128,7 @@
             "generatedTestHash" : "551b992bc1d991939b45186812717c455b77e84f790095eddcfa3d3cfb0b3437",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -243,7 +243,7 @@
             "generatedTestHash" : "486b7134a8c48d76fdbf0a771369d3b708ea14c494300ecca5c57098fdac0f46",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -351,7 +351,7 @@
             "generatedTestHash" : "36f136f8e3aadd5cfed85d12c733c79a94cef2dd71f5bce12668e4747b93fd6c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -459,7 +459,7 @@
             "generatedTestHash" : "e1a9ebb68a9e4e05f70a76b09f01fbf98cb862984646d2a189591e6908f20029",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -575,7 +575,7 @@
             "generatedTestHash" : "3e26bcc9cb2df2bf663f4283ed7d9067e81e4462c7827c4fac45049ecb812f89",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -683,7 +683,7 @@
             "generatedTestHash" : "8c31f16813d76ba359768da190e50585ce151e03aa3bb092d0de31cf434ac70b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -799,7 +799,7 @@
             "generatedTestHash" : "2f454bcac24e85543eeaad13db40612d17fe2b6ffe7eaed20d4c8e5d99d246b2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -920,7 +920,7 @@
             "generatedTestHash" : "fb0674fcbf0e009ae47bb9e29d02157d55965a24d67b0dcfd765396031532c96",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1035,7 +1035,7 @@
             "generatedTestHash" : "27b91d572125d5f7d3af7a0ba1cc22a8ac6c3a9b14673c54350f4059596e3c82",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1143,7 +1143,7 @@
             "generatedTestHash" : "3bd2693441f9b82b8575d2d6757e63967fcb3016bc3221e5ebe1345403bc5126",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1264,7 +1264,7 @@
             "generatedTestHash" : "9e765a110fb111e64bcbbba61aac8797e11aab01347c110c57317e283a2e03fe",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1379,7 +1379,7 @@
             "generatedTestHash" : "9aad0af88df49894aa855fb608d963ce6404bd1d351a49728dd391542b040c2a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1487,7 +1487,7 @@
             "generatedTestHash" : "6ae98396191bc03f7011f51b4ef2e41de166344c3aa140e2b2216293b1636252",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1608,7 +1608,7 @@
             "generatedTestHash" : "1163318b8e2803470afd8e66fe82c80ccd22ff5bc3eb47ed29ad3c1329a88768",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1723,7 +1723,7 @@
             "generatedTestHash" : "4eb5925ae9598068dcf4159e96c78fc3715416d7247603d7ae70c47022a5103d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1831,7 +1831,7 @@
             "generatedTestHash" : "a7f9c602aa4269862345624236a70bae65de5f2f537a4bb7318f52549dabe5fb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -1939,7 +1939,7 @@
             "generatedTestHash" : "40c49074477a2f411f57a172ceba93895e48a2b6ecd99b89225d1f006720a2d9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2055,7 +2055,7 @@
             "generatedTestHash" : "8112fd1c2a8932091fb9b0224d3cb71bc46d4b6da49e1783fa6db245a21c299c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2163,7 +2163,7 @@
             "generatedTestHash" : "e83f181d5dcf322093d6752e39c3d0550e6866cdefc57cfea063c4d2e37317b0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2279,7 +2279,7 @@
             "generatedTestHash" : "b4f433bcbc65788a3d539f8c3e21b84ddf3e57c0fb53fdc71b2e43ad332f45a3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2387,7 +2387,7 @@
             "generatedTestHash" : "c58ea4d60e2da931a63cee559d41819770eaf666ff3d024218d3a3f25db81e2f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2503,7 +2503,7 @@
             "generatedTestHash" : "5d64d84d313cc5922d081361a8386dcbefa1032e805d73c20874dd2d8b01b35f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2611,7 +2611,7 @@
             "generatedTestHash" : "df9fbec1a487dc9ce33bd4401f48a1c9d75314da323778a7001715a177f2db4a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2727,7 +2727,7 @@
             "generatedTestHash" : "c2cbd420f55496869bda1a8e6c0227be3aacc30a28d70c7eb7d436c841279a8a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2835,7 +2835,7 @@
             "generatedTestHash" : "0cb0df73cbb45253e2de945216e4518beaf2154208dc0c2cd017f5d467fd5265",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -2951,7 +2951,7 @@
             "generatedTestHash" : "4150df16ce49b28d1695275ab0f9b7a4e5c3dbec26d450fab4a6c6d4f37f8a26",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [
@@ -3059,7 +3059,7 @@
             "generatedTestHash" : "f09f936fc9397841189b10881b3b62cf9f054ff33edf70927e39f7f30af3220b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Filler.yml",
             "sourceHash" : "3424ab263f88eac50679b88a1325bad96fe21a859e94a0b4f68823a4b79a9fce"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "8ebce577f3b3457d00931ae8747763885ab04bcb398e9a56127a5b4383c07410",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "15c9df3bc1b115aa0108dada9dc9d420f6d99719957c2683467e20647ecc7b04",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -223,7 +223,7 @@
             "generatedTestHash" : "bf7c6ceb59ecb1d7d10a7502ffd2afb64134bf0262bc0e89da9923aab8a66f36",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -331,7 +331,7 @@
             "generatedTestHash" : "75022f3d4f27f8000ca87d63783d8c2bf78a01deeea0f8833eb10f25f28e44b6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -439,7 +439,7 @@
             "generatedTestHash" : "f99745bf63b446d7f620849549167cc2a456102ebc992a341a8304049f0691ee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -547,7 +547,7 @@
             "generatedTestHash" : "820ce03c8aa5933e4335a8a2182ff0eef837a6d334c214be7295432f5e9f774a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -655,7 +655,7 @@
             "generatedTestHash" : "be545955114b12e232a84492257cf8643059df2181a458edb02bc2eaeaa1611b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -763,7 +763,7 @@
             "generatedTestHash" : "d16b5c116f53ee07e909325235144ed2f24aa4f1149b6644326c1a5310ae2b88",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -871,7 +871,7 @@
             "generatedTestHash" : "f548d7a0070aef088e1cf9b3258cba51aafa2f29463e9d39a19a3561cf91ba5b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -979,7 +979,7 @@
             "generatedTestHash" : "aa54479864faf7a6521f8b42c31f2b5ac4b548381b44c9bb91545bc49b26aabc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1087,7 +1087,7 @@
             "generatedTestHash" : "a886de4817e9fd74c582e3204b55de3f5644243ce7408aa67371e0cfacdd70f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1195,7 +1195,7 @@
             "generatedTestHash" : "6847dc1fcda13d9f84e3a5b6a0d4dd17a2bc85c2b75ba6460886be8f70526b6f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1303,7 +1303,7 @@
             "generatedTestHash" : "6567c66883fab25187c5d83dbd6d6d52a509144c6259e4463885ceb7b735ec33",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1411,7 +1411,7 @@
             "generatedTestHash" : "0812e5ada5a9ffe773f14d756fb18d8e13249ed3de1fc61568065eb7c524305b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1519,7 +1519,7 @@
             "generatedTestHash" : "f0d61844f19af5cc7e73044db5650e1a57899f41c20fdf72208566f2ae7a2fdb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1627,7 +1627,7 @@
             "generatedTestHash" : "de6e6507e5677f0eb232834568e427a3226887c73a3faeb457d229dc78c78900",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1735,7 +1735,7 @@
             "generatedTestHash" : "5dd5a25cdd31ba7c7a0902fd26d3991548421f63af2815d6bbd73184bedf31ca",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1843,7 +1843,7 @@
             "generatedTestHash" : "388871277b9b7d7d8af8b952f2bd1fd04bad5e933d96371655d3155a072d66db",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -1951,7 +1951,7 @@
             "generatedTestHash" : "a600f71fbe949e5a5fcd5f60ea7a8913f4cc845b4e5868a6baaac4f47b17bc04",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2059,7 +2059,7 @@
             "generatedTestHash" : "fad0145b8787618b5b46b0f7bf289b1f2313175d0149d949282ad9dfcbfdf274",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2167,7 +2167,7 @@
             "generatedTestHash" : "30aa6c57830e3d6f1cec55b213a0904b8c8a3a648ad2233db9a9e1f266be42fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2275,7 +2275,7 @@
             "generatedTestHash" : "c1439f3ed32c6e7f7c6fb88f52faf48b49d2beffd3cbcfd8f3c3a2eeee723ad1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2383,7 +2383,7 @@
             "generatedTestHash" : "cb446ec62b1cf3b86c78301baca348550c84f011ff22c62ded5d39059ca9942d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2491,7 +2491,7 @@
             "generatedTestHash" : "686de281576a752b52cac4169ec8b1e6355eebe5b49c244f2a1288f09535c579",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2599,7 +2599,7 @@
             "generatedTestHash" : "970ba66f6214a6d5abe641cfd97657991e2ad25179e084e8b7555df31e5aa46e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2707,7 +2707,7 @@
             "generatedTestHash" : "6caed1231f3860eab20b7d46d18a7bd7fb7ef08cb30fcc3cea4afa503749cb07",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2815,7 +2815,7 @@
             "generatedTestHash" : "1d25742d0dbdbc4c2654f7f598bfac29faf58a765f120da3e3cfcce2deadb1d8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -2923,7 +2923,7 @@
             "generatedTestHash" : "4ffcf424c89ecc9638d1dfaaa94c7e5f9cf7718bf2e9947e9a809c76745fa163",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3031,7 +3031,7 @@
             "generatedTestHash" : "2c244278cf63ef15670454c2f9ab52aad2396900f9103ef9db1199d2927f08de",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3139,7 +3139,7 @@
             "generatedTestHash" : "7626a87529fd853eb9d0df06662df8b658d74dd7cc1e6bb81d7a028940f0bf65",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3247,7 +3247,7 @@
             "generatedTestHash" : "399159e8c9b1ba7708898891267f6dde67407a2652115980e8108c6720f8d3e9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3355,7 +3355,7 @@
             "generatedTestHash" : "81fc4d38dab923260486871f5b0c47aae2186274c09a51cc13218bb6d93832e8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3463,7 +3463,7 @@
             "generatedTestHash" : "580255697eeb64e5226e5526187cc22d31cb5eb5cbc4f2cadad829d9c54a9502",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3571,7 +3571,7 @@
             "generatedTestHash" : "751341bed2296d15bce020148f8a6a65c2493e7de95896d524581368955c5d4f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3679,7 +3679,7 @@
             "generatedTestHash" : "356b7f7a1393f249e14e51fac03a0a08fc2fd766285ea9a609f178616c9c23b3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3787,7 +3787,7 @@
             "generatedTestHash" : "21b27885c169a1fb93f79126825114bfa39a8e0f1e640ea363d4a22b943d3ce7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -3895,7 +3895,7 @@
             "generatedTestHash" : "389065eb4ff13c3db335f2d96d2807e1d68396cac3c043e35dfab8d46548119c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4003,7 +4003,7 @@
             "generatedTestHash" : "bb17ddd8ba89a732dafa86cd910bfe259282f9de2747ed06273536bd604583b6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4111,7 +4111,7 @@
             "generatedTestHash" : "05727afc4ab041f47fb45836bb799237df01f9a2e98180fbddecfa5990db5261",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4219,7 +4219,7 @@
             "generatedTestHash" : "bb1a1b523da852e92448346919cb51b2148c7097511a376cdb708453370fbb98",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4327,7 +4327,7 @@
             "generatedTestHash" : "85a1565393b1def8b305dc35e1d50b0ce3c9044d38ce32a32735c9e8be97522c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4435,7 +4435,7 @@
             "generatedTestHash" : "758c389f3f44cfc1888e1884780cbe64cb5b05b76baef1041f915cf80ef642a5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4543,7 +4543,7 @@
             "generatedTestHash" : "a434e10ca4102bd09b02e3fef3e621e38b496ebe6c04110be6fe9924a53b86c3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4651,7 +4651,7 @@
             "generatedTestHash" : "05b7dfe5c3b401a454fd7c812c31203e4f1560a40a5cc2c969ac23cdd544a8bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4759,7 +4759,7 @@
             "generatedTestHash" : "f23fdc945abb3874cd57df8aaabe61858f583176350dfe866da6f983293b78d7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4867,7 +4867,7 @@
             "generatedTestHash" : "50c1f147f226218fe62dfecd6830be364711ebd125dc92b2d2b70e80214650ef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -4975,7 +4975,7 @@
             "generatedTestHash" : "7ef28175de12c3f29c8ec192a98996edca379a80a16b71b18e9a81559486cb2f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5083,7 +5083,7 @@
             "generatedTestHash" : "5949fcbcd44d7731cd8127e2b9993cae9175cf2de06e626dbef847dbce053c19",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5191,7 +5191,7 @@
             "generatedTestHash" : "f33034300540d2504f260fa985a411fa05359e258292bb37c3d6552ecc71f499",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5299,7 +5299,7 @@
             "generatedTestHash" : "0abe2e6c37c09514cfda40ab2ecd5e7d52a9e53b6060d3184834892c72e36301",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5407,7 +5407,7 @@
             "generatedTestHash" : "7345ccf5f4d9d3bc67cc3cd91ededf5704d773b2138a8db318b5c5667495d3cc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5515,7 +5515,7 @@
             "generatedTestHash" : "e47adc1599c04a1e3ef1e3d041bb04ec895eec815b82eea37e26b8c2c8ca825e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5623,7 +5623,7 @@
             "generatedTestHash" : "d9d7bef533bc2f28e0943bff84a687ff7725d3117bfd019f7204f31d32a0fe20",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5731,7 +5731,7 @@
             "generatedTestHash" : "4c6943791400bb199c76e7276788e5b64f300f7a27fe6e0c518903578d1886d6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5839,7 +5839,7 @@
             "generatedTestHash" : "9dee6bdfa0158dba0a518a36439b6dc9c36390b56f046b790d2227c7228ab5cd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -5947,7 +5947,7 @@
             "generatedTestHash" : "31fe4981d56e0aaf6ae9a36ea8c94df545bc0f7a16b8cfed145293f825295856",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6055,7 +6055,7 @@
             "generatedTestHash" : "afe7325a45123ca4e6015adad0c59521ccfe62a9ff43354ef7a5ad47346a2244",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6163,7 +6163,7 @@
             "generatedTestHash" : "23e73f26191ab8c4f918826fa873b4880fe36b184e5470dc6daabc0326ec174e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6271,7 +6271,7 @@
             "generatedTestHash" : "ac3f834dceb11256f575450bcf7b13352b09a8fbe469751a61018b3f00866bcd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6379,7 +6379,7 @@
             "generatedTestHash" : "c388b1757204a7073c766eacfac1ca1e37ac6ccd452340276de957c2f1935356",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6487,7 +6487,7 @@
             "generatedTestHash" : "b5e255c0ed26dba99d25d39746ee2f109f65f976248047096c53d4fe64b7a098",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6595,7 +6595,7 @@
             "generatedTestHash" : "00b137a5db48d4ad0a350ed1a8117f7ec8eb3509ba9f2ff939d38c0e35b1dbf5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6703,7 +6703,7 @@
             "generatedTestHash" : "b7406f298ef43d8dacf40667f845d2d66213d0fcd5cc68c65e972f025ab5663d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6811,7 +6811,7 @@
             "generatedTestHash" : "9851e61a561abb07e3ac8d9e5d818d1cde487aa907d5078aa351314896e911aa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -6919,7 +6919,7 @@
             "generatedTestHash" : "a5977c3034c1ff64d5a5d1458e71c3c4780ee1080eb22ecb487888aa2a03686a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7027,7 +7027,7 @@
             "generatedTestHash" : "4b781bc9bed74b63cf9233aae84d7d60590e45708ba6f02f11b3c510144cf75f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7135,7 +7135,7 @@
             "generatedTestHash" : "939b1ff73630eaade78168e06d3b1276ff387998a674f75132dbaf050fec12e7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7243,7 +7243,7 @@
             "generatedTestHash" : "0f4e2afc372e83999bf72485a76f48addeeb107faa421fd93a53f8b149c53a30",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7351,7 +7351,7 @@
             "generatedTestHash" : "d16cf027758abb26af26837095afab56ec3c1df7f228647d9dfe209b08b0e8b4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7459,7 +7459,7 @@
             "generatedTestHash" : "f2f1574631d7119202cde0f322e1e65a690d19ab0c05b5f4e945c4f6521b4f9f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7567,7 +7567,7 @@
             "generatedTestHash" : "9c458632dc5c843a2a0bb5ff7aac8f53cd457205dc135f4befe761edecf3b91d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7675,7 +7675,7 @@
             "generatedTestHash" : "5a959db8cafe76957a0b0ee695238fc128d067e183c85427ae2ee6486f0431fe",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7783,7 +7783,7 @@
             "generatedTestHash" : "94df26beb7d09565448670ca9191eb0c9a82e41f1eceafbd436fb69b837a3fb3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7891,7 +7891,7 @@
             "generatedTestHash" : "1bf98900b22cca5ba06e896a110f7f536bd4328c5b08fceb3422eb4ae05e7d1b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -7999,7 +7999,7 @@
             "generatedTestHash" : "9be49a364c8396c5bf81481b91aaa42804a8ed2a6d831a3bea030af52d909bd8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8107,7 +8107,7 @@
             "generatedTestHash" : "eabeb21aba4e360d7ac4015de661533101aa0e5a763c04089196e9e390dddf36",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8215,7 +8215,7 @@
             "generatedTestHash" : "dd9d1b1d6997957d9e42a8f38d15f76ec9fc15ad68f4aae1a701af4a28588caf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8323,7 +8323,7 @@
             "generatedTestHash" : "62d477fab8cebabfa799127977969836d03cc7102da5369b3e17d762b7b9ec42",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8431,7 +8431,7 @@
             "generatedTestHash" : "9689b04870aa2dcf5b9f28978564979ba45648536391076f0b3e2e012e0aed33",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8539,7 +8539,7 @@
             "generatedTestHash" : "b556681eb18bf2f6812dab86c8518f30f59ff388b42690b4f0e7c956382da034",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8647,7 +8647,7 @@
             "generatedTestHash" : "11ed4b7b0a5cb4c02da4dd521a76fd72cfa3ea45f91e31a10d6b3a1dd8642c70",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8755,7 +8755,7 @@
             "generatedTestHash" : "b461b4a3854e1e55d4d3756d70a4f836b8d4a1f6641cee0acd9eda1ccd2f5ca0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8863,7 +8863,7 @@
             "generatedTestHash" : "6562a067ae73f7d492940f726235f86f2b364c83eebe75bc743299d52918f1e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -8971,7 +8971,7 @@
             "generatedTestHash" : "3f15f22f666c6917bb6054f0e042e09d5b6735d72884ff9f6483b14c292beda1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9079,7 +9079,7 @@
             "generatedTestHash" : "ceeef65105a558fce697a618828e0eb5bb67e5044e0713f213b385ecf8163ad2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9187,7 +9187,7 @@
             "generatedTestHash" : "ba6ea70b2bfc414d788d05a0519f6de57963cddcebc8cc20dd2b97090f53a517",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9295,7 +9295,7 @@
             "generatedTestHash" : "439525f0875cadc27476649366f2d6d0b7f42a685b36a8215e75f66b3aac3388",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9403,7 +9403,7 @@
             "generatedTestHash" : "e4771499c7dd773ca64431c1dd876b6bb45f51d7edd1d67919412874555412ea",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9511,7 +9511,7 @@
             "generatedTestHash" : "c01d2c85e3f9a06e85e88bd704cc4c649241968f7c68ee3c9c790478e92fc0f6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9619,7 +9619,7 @@
             "generatedTestHash" : "35ad0d1a0c9e2c93f3b6bc8b25cdb3e06797d2ff6fb4673066b9627329b975e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9727,7 +9727,7 @@
             "generatedTestHash" : "9eeb43cf3bab7053744ef66206beea0df4eaf3432df5ae2f3e96289de6f08793",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9835,7 +9835,7 @@
             "generatedTestHash" : "9c5722627f1abcabb840f58cc61582b96504ae22bcb04e3ad05bfc99f98b957a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -9943,7 +9943,7 @@
             "generatedTestHash" : "4cfdb9192c7ed0ecd989feaf49cb5e719e9b6b1318047842b5b46afd687fc0ef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10051,7 +10051,7 @@
             "generatedTestHash" : "96b9b8dca965bc3152af1f234044605f5586ea60de9f37d7adc8b76ddda05c78",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10159,7 +10159,7 @@
             "generatedTestHash" : "311a371e92fcaebdae49c96592fcd8fa697e1936e746944265512dc888dea517",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10267,7 +10267,7 @@
             "generatedTestHash" : "edb703b5e9974d5843fac7b184bcfde68e613cc41cb5fd59bddbfce97794e8f5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10375,7 +10375,7 @@
             "generatedTestHash" : "8e0e83c16a4fccae59659a5f17d2890e58cc36fd3b5ee1c829eb5796c720135e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10483,7 +10483,7 @@
             "generatedTestHash" : "1faab8c2f9160834e77b0d2a03d8aec31daae14ffea3672df024d190d2f51b22",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10591,7 +10591,7 @@
             "generatedTestHash" : "ca489c58e9605e46a252be30603fada64782657eb69f46de3d6d7f815bb776ee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10699,7 +10699,7 @@
             "generatedTestHash" : "7e7772cd22aeea778573ad569366c51d3de805197b2aa5c8776ee828284769aa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10807,7 +10807,7 @@
             "generatedTestHash" : "2be3be3bf14b04a4ef4d6c4114a6d404c2b799b0bd5107d3b64d162bc660360a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -10915,7 +10915,7 @@
             "generatedTestHash" : "c4b8ec7aad4403375bbdf8d15d7bb36839a4810c579072dae45ba88956826508",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11023,7 +11023,7 @@
             "generatedTestHash" : "bf1f19c3edf029fc48e4a63e9205f8602552d0c84a1c93ce19c6957d4dcef462",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11131,7 +11131,7 @@
             "generatedTestHash" : "638dab0ee4c94a56845a63f8cb68db3c62b2df1e8977c41c65cb15ab8a07f5f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11239,7 +11239,7 @@
             "generatedTestHash" : "51e5387fc8f3a10bcc8945e4bec1b20fdba3d358079dee950f66fd84928119ea",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11347,7 +11347,7 @@
             "generatedTestHash" : "9df54c6a8786dd0f487570027473403e380af39e44f264381d90d1e1113a2cfc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11455,7 +11455,7 @@
             "generatedTestHash" : "49bb439c8fe751e006070a9eedd64bfe5c23922996c21acbbe93bc5960224ea0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11563,7 +11563,7 @@
             "generatedTestHash" : "8a6b2dff9a96efb782aaf4dea20052efb5d3cccfcb66393d7bd152e2caf564ad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11671,7 +11671,7 @@
             "generatedTestHash" : "41c0f93c10a528de102d36d93703e319d7d9151c347a9daa876ca6582e3c7c39",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11779,7 +11779,7 @@
             "generatedTestHash" : "6dfb2c9d87cfda996a169cab4cbde060541f1df107395bec41e7ba6468b27251",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11887,7 +11887,7 @@
             "generatedTestHash" : "77d5b08cff82c3a742fb8336eb1911aa537f107f38bba36c5e96b13950728805",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -11995,7 +11995,7 @@
             "generatedTestHash" : "add0de7b763de188e75ae3a77240f92b5c500709ebd92917825d8d87e0ebbb87",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12103,7 +12103,7 @@
             "generatedTestHash" : "78c613f00bada720b9406de050048ddb8ce509c1ff7809d148c47bc849fc18a0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12211,7 +12211,7 @@
             "generatedTestHash" : "51df106967b9a39f02f7bf7c791f40e07bda8e4ecb9eaf03791db96612086c7b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12319,7 +12319,7 @@
             "generatedTestHash" : "b8b1d1ccda04f59bee4f3930ccf40043788a8c65e79169dc5c0b5b2ebae51756",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12427,7 +12427,7 @@
             "generatedTestHash" : "cd6facf6e3c87a58bbebbefca0bf440b60233e08388a0f909b0e6772370b6332",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12535,7 +12535,7 @@
             "generatedTestHash" : "f6cec1c0e97576cfd58b179327bda76e91250a72c8d7e1cae2b3d1e53e6ad469",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12643,7 +12643,7 @@
             "generatedTestHash" : "b02bf3ec70d1d5da499ec8bb8f290d38fafeda9bf67b707ca33898a52b7d28e9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12751,7 +12751,7 @@
             "generatedTestHash" : "c28d1005760d87421c803c68b8b26153f9a41cbc85c08da425859e91f56864c1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12859,7 +12859,7 @@
             "generatedTestHash" : "0f252c33ec278065cf9bd99be2e8c9dd1b29cba3f8b17521f3b55ee787a4ad4c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -12967,7 +12967,7 @@
             "generatedTestHash" : "d0e84ef41d4de0d12c08dd85fe615aa12f481d2712352629fb602ccfac47c667",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13075,7 +13075,7 @@
             "generatedTestHash" : "aaa5952c036539fddcecb97f77c8a28789b35a94e36c989a5e8d67441a460fd5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13183,7 +13183,7 @@
             "generatedTestHash" : "6161178cc78218e3d89d4fab9170b955dfbea42172196cf5a24102f0c35a163b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13291,7 +13291,7 @@
             "generatedTestHash" : "f2e8a8cbe9d932a7f89b8d031eb6fe7a15752c248a70ca5738569c471ab11641",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13399,7 +13399,7 @@
             "generatedTestHash" : "1eaaf86ba6eb5745e8fb6860109807be89b7b75433fa32be4bddb0ca9d98d130",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13507,7 +13507,7 @@
             "generatedTestHash" : "37aaed4976825baa05161293f1d05c363242e37427471d4f5481d16d565f9421",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13615,7 +13615,7 @@
             "generatedTestHash" : "95b1780327f2ca4258ca309cfe53407aafb9ae279444cdfebeab93c2c10b9d1a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13723,7 +13723,7 @@
             "generatedTestHash" : "5039e61acd97854a2f7ebc7f7d7d732d6bb011073e7aa4e46deb36d20c36a904",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13831,7 +13831,7 @@
             "generatedTestHash" : "70a1f846c19465c218bfa9fee607931ef25d60cc6257df11e9120c7e0fe3a291",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -13939,7 +13939,7 @@
             "generatedTestHash" : "ec168135834a5d3b01b4f711bd032a68b6782496b70726f0a86266229810e631",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14047,7 +14047,7 @@
             "generatedTestHash" : "5e5244805c1ee08a9f63a2cb64c83b088ffa4d4471a4facd943377f7c2b6a503",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14155,7 +14155,7 @@
             "generatedTestHash" : "c21cd42b4e077f544a35fa5a3c46fc7c3d85d3ef3bf8279830e1d62539f4d631",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14263,7 +14263,7 @@
             "generatedTestHash" : "2fdd260418ee9e0f9959aec1d134f748e79ffdf6a53b9937a282c30b76264432",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14371,7 +14371,7 @@
             "generatedTestHash" : "83a27a9a5627940dde10ddcbaecca5ab51155a9dc2e94bc5f0a77a03b2cd6f8c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14479,7 +14479,7 @@
             "generatedTestHash" : "1187b5771842dec38d46a0a3f8e500ada077b81df40e3e2e48c7c53c588984fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14587,7 +14587,7 @@
             "generatedTestHash" : "ab459cc312957c0780d51ebb7b2342430f054d296316bd89a9eb69e91b74fe68",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14695,7 +14695,7 @@
             "generatedTestHash" : "f3ba33044ff2e5e3f9faf49e85df9507070a352efbd608348521929badaa2d6c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14803,7 +14803,7 @@
             "generatedTestHash" : "e6188b9556754f1853e547e2e4cbdcc7c747c921400d72df87c4a45795905606",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -14911,7 +14911,7 @@
             "generatedTestHash" : "17b119e11e1304b9e24b37cb75b7ee5b90a4695f639af33f6eb97be689df4ce5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15019,7 +15019,7 @@
             "generatedTestHash" : "7182dcaad687b60d8ea6b60a17bb7b46e214195992b84706d0137e6310dacaea",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15127,7 +15127,7 @@
             "generatedTestHash" : "9fcb222f0dd4718164e0a5517c203165027c47d2d011b68a99653ba36f750622",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15235,7 +15235,7 @@
             "generatedTestHash" : "5958bd439100ac7a2f0f8ab1b23e279210f9f67a7ae428c1e2d3a69f05a57216",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15343,7 +15343,7 @@
             "generatedTestHash" : "0b5f58648050803da6d5707923746f19ed96f1c0e25c4311eb04299cfc1c40c3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15451,7 +15451,7 @@
             "generatedTestHash" : "6b4bae1e013398ae13f85d56a987d5d183e40073ac48dbf5c4211e8914fca0f1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15559,7 +15559,7 @@
             "generatedTestHash" : "4127b008f416367120d46db07463241aab9061ed3e7adf0648d874dec15241d0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15667,7 +15667,7 @@
             "generatedTestHash" : "b41cf47eb8df0bdf20c9fd268bd531d760e0ba58934d6237ca1a94f1d174ee65",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15775,7 +15775,7 @@
             "generatedTestHash" : "af91e5bf7cb168e280d81196fff5beb3dc6af77f898978ec2fbdcbab3ba62ddd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15883,7 +15883,7 @@
             "generatedTestHash" : "da13769dbca6215d0d20eacabe370e857490808d14f60b4fe9de5b51bb7a190d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -15991,7 +15991,7 @@
             "generatedTestHash" : "c86f287ade111843bcda21975866388d88172c8220eed1cc197be3301e596729",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16099,7 +16099,7 @@
             "generatedTestHash" : "79f3c2c43f5525c843d41a61d1673e53a29cf3da16a27a919da7453e37263db3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16207,7 +16207,7 @@
             "generatedTestHash" : "1bda2801e34f3fc20fb63c8a6486bbe78f8022953718e8017a56841be24c2be1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16315,7 +16315,7 @@
             "generatedTestHash" : "f863254042afbd3cf8e8e27a8e02088b0eb586d57e6c359c348e80067f98dcde",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16423,7 +16423,7 @@
             "generatedTestHash" : "f278ff7c9137f972967f5e30808fa161de8d3a79f4cc1fa8b805454c141f25fd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16531,7 +16531,7 @@
             "generatedTestHash" : "631dbf4f485801b8f5fc9e35fbbf2377bf08acc19aff876485169f5421f8eadb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16639,7 +16639,7 @@
             "generatedTestHash" : "f5513d9dc9eac144ee600265cc9ac4599655237d9d6a701a0b053ea3daaa9199",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16747,7 +16747,7 @@
             "generatedTestHash" : "34ee512bc84ba07ddbc05c2251119d17118bf59363267396d6063af749407351",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16855,7 +16855,7 @@
             "generatedTestHash" : "c48eec158d633650b882358edcbda771b49a76e49f5a74fd100f404230604562",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -16963,7 +16963,7 @@
             "generatedTestHash" : "257d69c0e39ded92deec48a712f2d39254778b63efab50129baa665986308c24",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17071,7 +17071,7 @@
             "generatedTestHash" : "0e565016afcd8ca6eead6ccdef1846f45700c90109cbcd52b9c4382b0fba3eed",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17179,7 +17179,7 @@
             "generatedTestHash" : "d214545d59434f1a5dc86f9beb1cd95238f20ce7068cff6833c106f7d6779de5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17287,7 +17287,7 @@
             "generatedTestHash" : "6011bac7285604a95d4cdd6031eb60e747cd6e3024a98779126c1a3b274ec8ba",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17395,7 +17395,7 @@
             "generatedTestHash" : "b8ea9018463d527ff442598f948b445f05e1581e05cb1ee76198b809da1a2307",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17503,7 +17503,7 @@
             "generatedTestHash" : "b2cce47dc185e04093c733443c54b9cfb7d31df0060d5057da4c638e84d23d3f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17611,7 +17611,7 @@
             "generatedTestHash" : "b7e383da099135d989fded162cb84156d30b6c046612f796360bd1a8003cdbf3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17719,7 +17719,7 @@
             "generatedTestHash" : "b8ee72392089ff49415f0e9735e6b0afcf96c7980e053c39212f0a1b7a071c33",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17827,7 +17827,7 @@
             "generatedTestHash" : "4be95482308742e75d2cd8ee3a14457e7452b8279fb940dfb839ed10e2c8b820",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -17935,7 +17935,7 @@
             "generatedTestHash" : "05f4a404f60c7446e4371e22a2edb4813e15af866a82b8afa94d4452d721795b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18043,7 +18043,7 @@
             "generatedTestHash" : "70e22ac8b36906db7b3d9760112b440dbc94edabf3b550b42057cfdcf93eb491",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18151,7 +18151,7 @@
             "generatedTestHash" : "0232891fafbcb3c8f6a38198a3bb695a0ea0e1d97aca5fa50870518169181dd8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18259,7 +18259,7 @@
             "generatedTestHash" : "176318db09e864367010123bc80098113abc55effbfd89c0eeb2fac9bc28a981",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18367,7 +18367,7 @@
             "generatedTestHash" : "96d6cf14df0b3f35761047a0f24603d70a6b6ee6791416a44569346ba1b0989e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18475,7 +18475,7 @@
             "generatedTestHash" : "827eb37dd0babd000f004eb8e3a2707804a7f17d8bbab0dcc5ec2d2b6d8d0434",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18583,7 +18583,7 @@
             "generatedTestHash" : "1dbdb88f43ce5b955f5f79c58a613aece4c353b1587a992778d50de8c0d0d072",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18691,7 +18691,7 @@
             "generatedTestHash" : "78e6351e06f107be9dbb7485d45294054b4c6fced537855c2658715b08eada2b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18799,7 +18799,7 @@
             "generatedTestHash" : "f1d47d9cec2d3258664da0fa2f055f192059d6f4c74d45f6c3be999b9b50d9bd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -18907,7 +18907,7 @@
             "generatedTestHash" : "9d08b98d3a52e04e3f840f744b06c8ce4661e97f4531ed55fdebbb8de1d69cb0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19015,7 +19015,7 @@
             "generatedTestHash" : "4e9296ae870955eb5fc663b2dce6e634750d2a9238f2acacde20c053ffdc833a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19123,7 +19123,7 @@
             "generatedTestHash" : "5830454bec5c205b75db82ba0993cccdb445acc284784ca32e48f5d153c28bf9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19231,7 +19231,7 @@
             "generatedTestHash" : "13cccfee8452fad055d558d3269a4aebb5acca4cbc50a41ab80885aa79430677",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19339,7 +19339,7 @@
             "generatedTestHash" : "bd5f9adc14c0a7a97007883ce909e04174106685d74f6dd722901199faec7791",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19447,7 +19447,7 @@
             "generatedTestHash" : "53fd14047f7e5f61c4a95c0d90e2e59172aa116ee76478e74fba434db3d630e9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19555,7 +19555,7 @@
             "generatedTestHash" : "2906df24423bbc730ea4da615f1e380551ec2e0de5897b684322a4024e2d1d9f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19663,7 +19663,7 @@
             "generatedTestHash" : "134614e56ccc83882f2b3beab1e4a1a308afdf1f30e7aa56f6e11142adab5810",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19771,7 +19771,7 @@
             "generatedTestHash" : "d9a982a5640053e1864ffb6edb623d6cf3b0e6646108fd15c2aa270129098e05",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19879,7 +19879,7 @@
             "generatedTestHash" : "4264b6827332ec4d0fcff9f7cf1e4216582f9ad30503cd1baa69e379a3a70d4b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -19987,7 +19987,7 @@
             "generatedTestHash" : "1f731d0617bffafd177d057af6bcccff1c68ae3bb5b8c30bb2fdff19f024cd1d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20095,7 +20095,7 @@
             "generatedTestHash" : "f7ddd436d9b4c259d496abd4ef32072d54cf370b5c0cdb05bf3be167a9e7f9d1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20203,7 +20203,7 @@
             "generatedTestHash" : "dd556ce76099501a5a39b67e2edfc9867e6631fd5ef7d6d82c05db014bab5cf8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20311,7 +20311,7 @@
             "generatedTestHash" : "ac2a5b4d734fff8c534d014ba79e450f936f6cde50401afd7b8eb3ed8fb47a67",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20419,7 +20419,7 @@
             "generatedTestHash" : "c79bda4bce5d5814dec8fa212d53c3d11df565d11f762b57b2945ce30dbb6127",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20527,7 +20527,7 @@
             "generatedTestHash" : "79733acf576b2bebaeef4a83543b9a08a05c4dcbb22fbec703fb15476804c919",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20635,7 +20635,7 @@
             "generatedTestHash" : "579e0948bea612380d3bf194d8fdda154ed695bd04ffa5acbd402c97a48fef19",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20743,7 +20743,7 @@
             "generatedTestHash" : "5e83e8867bf4bc05e76e1e4b273e8528ab865b0105b722edaa1daa3a3f7de367",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20851,7 +20851,7 @@
             "generatedTestHash" : "b6e181f518b4345b80e998b19a4c8fcadb08c94a73c39157cbaf2f156e9855e5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -20959,7 +20959,7 @@
             "generatedTestHash" : "13131834d2aa9be7efffbdf22c92aed09b17c0d64a431e7ba4ca1f32558528ad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21067,7 +21067,7 @@
             "generatedTestHash" : "28390883a72e2049ec278114f01e27874807db12b81931cee9b94e21dde0dd0c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21175,7 +21175,7 @@
             "generatedTestHash" : "faeee410bc5149129a91ff7a6c03157203f6b1150b0e14d56c0779433b5a9ef3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21283,7 +21283,7 @@
             "generatedTestHash" : "4aa5372450979b18e9ad9ea8a420ef8ddfd10a457accdc47aa2f69b1fa196cfd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21391,7 +21391,7 @@
             "generatedTestHash" : "dceacdd75e68950ba7720361fb688e64004800cb69f3b15d4c06a8c565480aee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21499,7 +21499,7 @@
             "generatedTestHash" : "3553c4f7e033bdbd860e13efec8b817703fbff9265a4341d99d9ffc8fe59e765",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21607,7 +21607,7 @@
             "generatedTestHash" : "23b953d5994d2caa6e805ac4c0ab6244fd73bc34975ce3b9ad50c1e16279e3ab",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21715,7 +21715,7 @@
             "generatedTestHash" : "38913d3e25b44bae8d695185f17dd923bf6eb7f521096630d64dd4bf957f3818",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21823,7 +21823,7 @@
             "generatedTestHash" : "d939a8a12e1c00039c13171108a19524817ba8663d758f29f4837fb7603fdc2d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -21931,7 +21931,7 @@
             "generatedTestHash" : "a212c0dd71020f1ba461fa844eef2077fef44d1479171741b4d6776f84e0c4f7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22039,7 +22039,7 @@
             "generatedTestHash" : "20769a347566afc5b9014a1fe99b2424fb22b4e7391341e739b81e544c351e66",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22147,7 +22147,7 @@
             "generatedTestHash" : "55b42fae6c4aba560e79e2ec4079722be8762e0f431c02a7506e8e5c19bfc19a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22255,7 +22255,7 @@
             "generatedTestHash" : "244f539a693d35aa82bfcdc4ee04fb678cd0297cbe4c4048f2bd5eecd52d5b5f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22363,7 +22363,7 @@
             "generatedTestHash" : "d9bdc4661b648877f0670db253818917ddb8e646ec3e8b840ad51182a8d89a8b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22471,7 +22471,7 @@
             "generatedTestHash" : "3a8fc4ca813ee0e5585997fd60a680d252f6fbdaf8bac1f0d2ef0c68ed65a888",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22579,7 +22579,7 @@
             "generatedTestHash" : "3738d874849b775916bcfc3679f58ed1d4130b1404caade78d91b61cdd26a92b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22687,7 +22687,7 @@
             "generatedTestHash" : "98a112549d4834ff4d07763d3bda39e8dac46928b57ba257ae646ca3833258e7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22795,7 +22795,7 @@
             "generatedTestHash" : "d5f09ccf73b30a6810d616d1abc105326d3bbe2bb0c4838fdcae9aee3ead3e9c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -22903,7 +22903,7 @@
             "generatedTestHash" : "998dd9a788e821fbaed4bb4c3cf24d6d991924495a2db6d230a8ffc452c43f2f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23011,7 +23011,7 @@
             "generatedTestHash" : "b40d88aaef7dc2d8f51ded716a3d7956bc0dbf03c021577fad14c829d753e635",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23119,7 +23119,7 @@
             "generatedTestHash" : "8e41c205c48a5c37e72b0619e4ae29826d058d5117e598f26a441c55237edde3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23227,7 +23227,7 @@
             "generatedTestHash" : "4f727a4c55485d26dbcce4ebd73853f47c2e171f482d4d3b7407c7816d002509",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23335,7 +23335,7 @@
             "generatedTestHash" : "89b4043246d3d8f32322338a1a6bcd70ae43f39fc5d03c06ff682c40fa8ae8cd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23443,7 +23443,7 @@
             "generatedTestHash" : "ecee9799ac7d69aa8f04a2c1d49847610b411e71dc651f0ae36d84b55c050e73",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23551,7 +23551,7 @@
             "generatedTestHash" : "a532c806292d2547ba2d12051ee8d1c1a9133207238eb0be066542413caadb11",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23659,7 +23659,7 @@
             "generatedTestHash" : "0a886eb5ca20eb5fee064ab7eeb10c30df4e35bf0a932aad83a4de81a34c38a8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23767,7 +23767,7 @@
             "generatedTestHash" : "4f2897231ad81ba5fc93dc1e64793ce31b0de9a794663951eee4e16db77f9e15",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23875,7 +23875,7 @@
             "generatedTestHash" : "74a89be3cf94ebd858105dc73e019ff3f18c89ebf1bb9dec2ddafb2d1dbab165",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -23983,7 +23983,7 @@
             "generatedTestHash" : "440dfb19e6ad7a87099b0429a1b47d98d5fbccfd949e47b7224648924aa325d9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -24091,7 +24091,7 @@
             "generatedTestHash" : "7c6c238dceba4e482eb9059099cd0600fd47f05d200d60640c3fd943515dbb4a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -24199,7 +24199,7 @@
             "generatedTestHash" : "be52696504e09ae7d18dae6fc9d2bf06f94663f82afca99cdc42561e727c21a7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -24307,7 +24307,7 @@
             "generatedTestHash" : "807c1a2159e885989bfd74199fd5169c088d162d8f38671be54e44776abadceb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -24415,7 +24415,7 @@
             "generatedTestHash" : "b87cc6c55b9bcd9d8600a139b094fc890790b3d935964a2c456fa4648b0d9ac9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [
@@ -24523,7 +24523,7 @@
             "generatedTestHash" : "3150f460cb2c0b69a19eead4e753db413aedd4296f77bf8a6833c8d42b12cf38",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1InvalidFiller.yml",
             "sourceHash" : "c46a94cfb0e050c23e058d78488891d629813dfe87bc64d2b2f723521fe1f02e"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid_FromEOF.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid_FromEOF.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "12e2cff2e45ba43fbb83ef2ddc0799b938b29d2d31c37cc696059c83fef14759",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "ab4db481453932d78988db06bdba9b057f286c1bae70d37676766180352a9559",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -223,7 +223,7 @@
             "generatedTestHash" : "3f4987fdf03c5bdbd86ffac6b2bef8cfe7c531149eb90fbc861aa1f092d539fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -331,7 +331,7 @@
             "generatedTestHash" : "82c68d78b19ac8dc7ab11e871f6ad29292d0d3d6da6d660eb3899ce66ce56eee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -439,7 +439,7 @@
             "generatedTestHash" : "9f5dde6f9dd5d4ccb814c65c053a454f948dcbcd0ca8fdb3f84b3c2dbb5642ef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -547,7 +547,7 @@
             "generatedTestHash" : "04ac1634087e9b5aab084ed1ce7f4e2ee25bb2d44f97e804e16d4e059e1a2db1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -655,7 +655,7 @@
             "generatedTestHash" : "1d2ef0b362f44b138fbbb519fcccaf847a2c0410862f2c9ecff1b748e04ccdff",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -763,7 +763,7 @@
             "generatedTestHash" : "7ff25ceba8283492c9eec857c4fddb3667912c0eadefc02d965f01f8e2baae57",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -871,7 +871,7 @@
             "generatedTestHash" : "960f469027017ff4ef5bad7e75ca0060ab2860f0edb0f9a7e4226e27bdf25d32",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -979,7 +979,7 @@
             "generatedTestHash" : "5199e0c2f1797e8d9d93899986b9225b0699a329e8b8d9262b551214db6064ab",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1087,7 +1087,7 @@
             "generatedTestHash" : "5368827637e930f5c400e235e05ff2de3ea2398eff766bd902e3f3ef65bfeaea",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1195,7 +1195,7 @@
             "generatedTestHash" : "bb9699b6d305b8bf944e332011d3ba492fcb82beff36ee32cae7597c025a8b10",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1303,7 +1303,7 @@
             "generatedTestHash" : "69e48b51d2cb03dadf87f4594c5bc84a860817fe87d812d7d43e91ffe36df7c0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1411,7 +1411,7 @@
             "generatedTestHash" : "20908bedd070479be0ec011c08a4c9b4fb447a07b01f15c5c4453fc6d63c1c15",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1519,7 +1519,7 @@
             "generatedTestHash" : "3387281457c169ce11db9538495f6193bc6c402e0dfe5e6d028ddab551299f08",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1627,7 +1627,7 @@
             "generatedTestHash" : "1167efdc366ce0dc42a26560c7ca2e6479da3266033241eb1ea3ff6bbfb1278d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1735,7 +1735,7 @@
             "generatedTestHash" : "60abb348a5f2ef03368bba45c5f449c6b1e0b3d6aa86a191e444fa770ed672fe",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1843,7 +1843,7 @@
             "generatedTestHash" : "6dcbd9dadad8158d3d972cef6281e0cd27ec32d17a3fc3970151a414b223875e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -1951,7 +1951,7 @@
             "generatedTestHash" : "3a302a5e6616182097730c5c5ae15357d43eb1eaf7002cd45733dfac34fa2d69",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2059,7 +2059,7 @@
             "generatedTestHash" : "13de42cf00bdec0750679f4a86d2976ee99c1d04ab702d5ac6efa163fccd5d89",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2167,7 +2167,7 @@
             "generatedTestHash" : "b4ce998edb49430ecd168ef7739fdd296768c99b426441d00d54c8c5cb346d59",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2275,7 +2275,7 @@
             "generatedTestHash" : "73834db0f9addc82bfb57d4ed97b3b943388fbc4374a4ba486e68351991d5316",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2383,7 +2383,7 @@
             "generatedTestHash" : "f7ebea33f91742204b5170101084b885cc7432a3f66a02beb73472af0cb62dcf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2491,7 +2491,7 @@
             "generatedTestHash" : "05f63b2ad6b5dcf5a93295f3b811c551d19a1dbb6672b14f32d961ba91805ab6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2599,7 +2599,7 @@
             "generatedTestHash" : "0a3c31dfa065adfd3b35d64eb7d1bacd4b24fb1d6324f8ff555041d7f244d290",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2707,7 +2707,7 @@
             "generatedTestHash" : "593d7c7ce03b744e85e15d1a93da8124c3bf4d3aeb9a843a34f0ae366c9b7a8d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2815,7 +2815,7 @@
             "generatedTestHash" : "aefc1dcce6252e436ed2e490ad7dc947b48c1e5589c3557d17448cfece3d4cfc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -2923,7 +2923,7 @@
             "generatedTestHash" : "d8c7f19692f3c09a4a2d81f1d0e47be01ab874566238282fa14eb15954392568",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3031,7 +3031,7 @@
             "generatedTestHash" : "57b04b4305a0ae9e307d345c573c6f2c2aa13a7cce6a352b7bc7680b70956399",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3139,7 +3139,7 @@
             "generatedTestHash" : "e41f78ed4b41391a5f210225a7d7df92eb2b4c80b022c6e08690674de81607ed",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3247,7 +3247,7 @@
             "generatedTestHash" : "fd971de969fedf77095f62637fe72d279dc08dbe84bfd0edb6f61446e3a13ae9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3355,7 +3355,7 @@
             "generatedTestHash" : "031fd567b2462627a3369c19c88f1d19c2841b83c6cd9b9de2de943f62a8c50d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3463,7 +3463,7 @@
             "generatedTestHash" : "53c4981713eb77ec30776d7e61edafce729a2ea3ba4c22ec2deba59670167664",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3571,7 +3571,7 @@
             "generatedTestHash" : "389a25b5d0a720d8a23e3c2b5cb78c33f300a9f1ce09b5e1b90322866d9de06f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3679,7 +3679,7 @@
             "generatedTestHash" : "90498d856f47811812745871b9075c1d5deb11614665050468b4c7ddb9a71b32",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3787,7 +3787,7 @@
             "generatedTestHash" : "de1e4d0ee2bb0cbc19d27de9c0e112c3a28aba4184a18d3ecd8de50d9f168cfd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -3895,7 +3895,7 @@
             "generatedTestHash" : "40bccb9b6d0f3a617be12fc14e60eb815a94020f9f4199b4d1ec8a7e74c8866a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4003,7 +4003,7 @@
             "generatedTestHash" : "bb57caa2e429ee1b1b2191df779056302876189d3aba64304a6e6aaf7f437274",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4111,7 +4111,7 @@
             "generatedTestHash" : "46813d1014ccc69b3c850f6cc6c4e24e0622543f421c388ecad0c3e9602bb728",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4219,7 +4219,7 @@
             "generatedTestHash" : "38d7e899077c46bcec9b0229aa0197f6745cdb6906403ea773db0a4fab09ea8c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4327,7 +4327,7 @@
             "generatedTestHash" : "a53f6d9a8d2c50995bd7293417a58563f9c63a0ca16ae6b2861419645457e289",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4435,7 +4435,7 @@
             "generatedTestHash" : "c3eddb219344896106319d91b38d29d429dd08fe53897a0fe78d5edfb0fa9e6d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4543,7 +4543,7 @@
             "generatedTestHash" : "754682a9151caa4e1da022f6b3cb0b59c9b053f94f0d7522566f460e11245046",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4651,7 +4651,7 @@
             "generatedTestHash" : "e3017166fefba76c703b1c627783c32db4e5c5c408e57a0c2c425e985266c097",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4759,7 +4759,7 @@
             "generatedTestHash" : "86d069c5df4c4616a7d5866dd4435d3a8ebabaa474e4b824fa1d189d01229313",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4867,7 +4867,7 @@
             "generatedTestHash" : "d20e3130a27659085db1ad7e6dab080dff6915d4b5ae86b94af370efc0f36cfa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -4975,7 +4975,7 @@
             "generatedTestHash" : "4fc1f90b47a25d53b77350d3afbd8ee2ccf4095245d96550090d244b30a488fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5083,7 +5083,7 @@
             "generatedTestHash" : "f75a3badbfda096e3c1a662c3151664b702516ed7c468dc0b3e75442dabb9ca4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5191,7 +5191,7 @@
             "generatedTestHash" : "e91c066e436bd9e54b2e8bf7dd310bc0e537b130f0880eafa6624bfe8547bd2b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5299,7 +5299,7 @@
             "generatedTestHash" : "594e193c132a4b848172ba11e064163205ed25b9f5edf9e4906c7299c53432d1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5407,7 +5407,7 @@
             "generatedTestHash" : "91237b9935c34821bad99e4a6bc7c292628e35e7a5344f20a23f2ada07996871",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5515,7 +5515,7 @@
             "generatedTestHash" : "08d0391020eca7e6b8bb264c34555ac162fd27f7b32db675b33e8966ac730e5a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5623,7 +5623,7 @@
             "generatedTestHash" : "3e4503e8ccb6e9fc0007e55820e1e760f46080a84aa41bc35047ebaa7c1234d5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5731,7 +5731,7 @@
             "generatedTestHash" : "2c631fec68f5b67e93f66cd352db09b864ff1c7234de0be80569b44325d3a967",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5839,7 +5839,7 @@
             "generatedTestHash" : "7f1ae478a24af027ad21dcdf37c5406aea32647b3422b1af33e72a536040582e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -5947,7 +5947,7 @@
             "generatedTestHash" : "8dd0c6950a459bb3d6c48699028deea8f405187be7742b4e67c68f6af278cebc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6055,7 +6055,7 @@
             "generatedTestHash" : "dec00b9693b2eb48c05886e6300be349517292a61440eee548720f5684fe0659",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6163,7 +6163,7 @@
             "generatedTestHash" : "0dc9569819aedc94a3b2d6b5d5cc1c24e72abeac6179812fad6c67af1404a0b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6271,7 +6271,7 @@
             "generatedTestHash" : "6b56fa7e1f6e16303adb2c04c4f080e2fa5a56f93f64046318b4110914e936a1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6379,7 +6379,7 @@
             "generatedTestHash" : "9f409d1cd566d98e8d6ff0c11263f7ec8296c075e2c6e3bc5c0387c61429d5a7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6487,7 +6487,7 @@
             "generatedTestHash" : "20b1a086f6cb6c24c3669aacc5f30e666d82cfc286a0c6562d68aef45d9f5286",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6595,7 +6595,7 @@
             "generatedTestHash" : "7530c3d611549e5cf5e351adcc392e16787900a00457a051b79de241e6ae53bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6703,7 +6703,7 @@
             "generatedTestHash" : "2b775af15e70f93bbfc0b90e03bf466b6eebe40d51a860d1e7637f6088d4a56f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6811,7 +6811,7 @@
             "generatedTestHash" : "bfc49f1fbf382da69dc323f7246d6c3d8823bd240daae81a9b0fd9d8120591bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -6919,7 +6919,7 @@
             "generatedTestHash" : "ef35f962ad1ea266c1f1a27831978b63743cf3db05503f21af0dbbdc635a19cc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7027,7 +7027,7 @@
             "generatedTestHash" : "e4817430fe9e24a4821e6729e735ad9aee9735e54d94df4ebee3fa6f4ba728a3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7135,7 +7135,7 @@
             "generatedTestHash" : "c9c42eeb04449093ffa93e4b50c462eafeb6f7f36eadb593266b398ae6cf9a2a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7243,7 +7243,7 @@
             "generatedTestHash" : "6778329fbfb20243aa26585647b3e67549b26093a0b9a7cba3ca6f17e2f3b081",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7351,7 +7351,7 @@
             "generatedTestHash" : "95b53f9d61ecaedc34c608391bff181125e621fc4d698f8ea6cb73201a606194",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7459,7 +7459,7 @@
             "generatedTestHash" : "dfdc040ea81a2876d67bb844a2ed3852a4a58cc5f3956e30fff299c2adece788",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7567,7 +7567,7 @@
             "generatedTestHash" : "0c63865d9e5d24b0d5c5eb3ae2cb216fc33ad983ba392b6e06337edac20ae536",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7675,7 +7675,7 @@
             "generatedTestHash" : "f7a4b3a8dc4afd6d37fd710219eee69b0587830436d2d808fe9de3621944b328",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7783,7 +7783,7 @@
             "generatedTestHash" : "b3b84c738cfdba9f76d274e266d220f3112f6ab5a8d4b75baf7051306d9dea31",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7891,7 +7891,7 @@
             "generatedTestHash" : "799328a5de16a96f98e022d007737e0177c576c2eb8ca7dbf7be3304244c35c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -7999,7 +7999,7 @@
             "generatedTestHash" : "c6cf99ad1489220fd22fb63c75a1649dc67bb1362c97fcc562740b5500d0e2d0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8107,7 +8107,7 @@
             "generatedTestHash" : "9d04fac0aba5a12a556cc7f76354f9a6dbf49310fee239ef82dfaf6ca0c9110c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8215,7 +8215,7 @@
             "generatedTestHash" : "95bb83ebec504c62950f162ee669d281725b3d0983a28c446d7b88743fb14e87",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8323,7 +8323,7 @@
             "generatedTestHash" : "dde52a6e4ac4236d47b60f282975130a32e96c2b48975508db76f45cd504d3de",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8431,7 +8431,7 @@
             "generatedTestHash" : "493d600edd4217ce784b275182017a9465cbe85eb2f10846d85797290ceb3eba",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8539,7 +8539,7 @@
             "generatedTestHash" : "36e49f14ac25487abe4728b3986694b37c674e273710b2ec51e587bb6f7a6fe6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8647,7 +8647,7 @@
             "generatedTestHash" : "28d958ebc13930ca7a59f21e1b5770c60fa75fb27cf6ca3844cc168925dbbbdf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8755,7 +8755,7 @@
             "generatedTestHash" : "a198f113643d7c02a7d6be35b743e137980335bbbc0ad11e9a4be8b253144e26",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8863,7 +8863,7 @@
             "generatedTestHash" : "48882e2b4a3eec33b97ca3ce3863235fddeb005d5dddb6c878a5ae2ac5cd23d6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -8971,7 +8971,7 @@
             "generatedTestHash" : "1b8cae783548104beb4fbc5dcce0e18bee51f9062d614f03336e262bf991643b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9079,7 +9079,7 @@
             "generatedTestHash" : "458a0985124f58c8362d494d6ac7c44238adf3c869c7124a1ac144f50c22fd68",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9187,7 +9187,7 @@
             "generatedTestHash" : "f48e39e6301f9806fd3f4b5199193110db451651090d3707efb4c48dd2f5345f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9295,7 +9295,7 @@
             "generatedTestHash" : "bb5c237de8a47a3b1e579f347ea38375e8cdea347fbb88c1a03e4a1a61783430",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9403,7 +9403,7 @@
             "generatedTestHash" : "60b41e0ad5b95602ecb9578320da3172921cc65a1ae50ea48c7df1e5635a41d2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9511,7 +9511,7 @@
             "generatedTestHash" : "dbf8af2660c2b40364fa4528014ff6e7551cb8229b3a8b428dea55b89f85c38f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9619,7 +9619,7 @@
             "generatedTestHash" : "0dab56d1851f92d791fb629f402f57fce16c7362a2b24dcc8a29e4ee9a75305a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9727,7 +9727,7 @@
             "generatedTestHash" : "d9da5cd0a105bc3bf1c35898afa17aab78bfa71d2f5bf6240896b5868cf32bfd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9835,7 +9835,7 @@
             "generatedTestHash" : "f1e468a3a604173e92191bd8c0200c250249d0242d3c835c1349a9427af2f7f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -9943,7 +9943,7 @@
             "generatedTestHash" : "af4b2b5f7994de801db023347f987e485838dc57206a2c343d356172a10ff409",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10051,7 +10051,7 @@
             "generatedTestHash" : "d6e692aa5ca8c041f0a67a8d584eb17ff582dad5632ebe78e11cbbd630c0e769",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10159,7 +10159,7 @@
             "generatedTestHash" : "0c7fe12a13a76cadd9bcf723b4b505f452afabee0d4751d00fe865583c3b0dcb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10267,7 +10267,7 @@
             "generatedTestHash" : "3e71961478e81dd4ac116458d8b0d5e3fe82bbcd81f2191988b60c8d315de50e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10375,7 +10375,7 @@
             "generatedTestHash" : "78cc8e1305a894e71b1ecd18092cd2822c7af16f8a7e6fa424f3e3c678b46e00",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10483,7 +10483,7 @@
             "generatedTestHash" : "08d81328af43b5f10ee729d5f3c8aa72035d52b16a24f952ec6d051a3da1234d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10591,7 +10591,7 @@
             "generatedTestHash" : "7584d686bf252b4acae5fd530e4ed4259ed80bddf04328d7c4385144d855a3f7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10699,7 +10699,7 @@
             "generatedTestHash" : "a0f43d5e466852a18c3b3c7acfd6d07aacc733890ce481fa003e37014cf9f087",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10807,7 +10807,7 @@
             "generatedTestHash" : "883684721fb62acad8d690c1cf7ea812c25f77d9059e6d1f96ebb3f1c7bb7a17",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -10915,7 +10915,7 @@
             "generatedTestHash" : "3e3c63da52a156e8e22528a5accd67308099c82d0bb9d28b6007028dcf941c13",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11023,7 +11023,7 @@
             "generatedTestHash" : "567dbd4edc43f5443315192443bf9e82ae342f9491099758f3e263e84d321a2d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11131,7 +11131,7 @@
             "generatedTestHash" : "3cce42f715c5fc6d08d296f2e05a9e3f49607d2c927c59989bde5755dc14568b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11239,7 +11239,7 @@
             "generatedTestHash" : "e5edecdc6cb2c003b5c9bc86ffc3c8d204fe7465e4595d57915806615d1d6107",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11347,7 +11347,7 @@
             "generatedTestHash" : "9cbd897a3ef1049c68097e8c7aba1a13a21cc9d36a114b9194eb4695f613be25",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11455,7 +11455,7 @@
             "generatedTestHash" : "f47ec3b1414e0f65f68b1c22478906b6a6137bc98c02736ecaa485ce5852e726",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11563,7 +11563,7 @@
             "generatedTestHash" : "d5f9beaf736357f4f4eb73bce5b233c277c3a4f9853a6fb92a47ad498ef24c55",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11671,7 +11671,7 @@
             "generatedTestHash" : "94443d69e36a6ec9f3b75a6f1e4098183f50bdb257373e042e7a3f12dec53fad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11779,7 +11779,7 @@
             "generatedTestHash" : "b5668966755387de90a28b1ada118ee7554728fa4f6ee12d485786735e6da727",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11887,7 +11887,7 @@
             "generatedTestHash" : "80d3d98e382f3b5b5ff73c3b80b706e39852f2fd498b79ae9f81c2f635b5c36e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -11995,7 +11995,7 @@
             "generatedTestHash" : "6316404057e5014c547f3bc2835dbfd050fcad889c83a364e03638a0e5abba1f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -12103,7 +12103,7 @@
             "generatedTestHash" : "802ff6bc7b7a3bcb175952dafd413c4b76f11a0592d6fc8b8cb3773fbfb8130d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [
@@ -12211,7 +12211,7 @@
             "generatedTestHash" : "cc35c7a9152bd1a50b5e95484c1457c16630cee38bfc65991e938ecd7b6abbd6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "60111a0f846e9e08bae6f066e3e0b682a32de4f259e2103ed42887ce06c3a6c6"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1_FromEOF.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1_FromEOF.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "a5c45d254ca7d3f32b326563314002e5179c89b859527f2582c18806faa8181a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "97ff5a90fd21f92e3d5502195667f2d4293af2a1b079ad7663e91efafc62a1d2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -231,7 +231,7 @@
             "generatedTestHash" : "463ac0ff9dbd1e97e985fa9c24655df9bc3862e79e4e9cc627a17cae850f1f06",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -347,7 +347,7 @@
             "generatedTestHash" : "e70789e3637d2da3c4d104faee13cb921d552f5de04e963e7cacfeaf6ade8070",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -463,7 +463,7 @@
             "generatedTestHash" : "000517afdf2d0fdb13909d26e7374f84fe0ed1d3cd6d54d2a941c66f86e70547",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -571,7 +571,7 @@
             "generatedTestHash" : "5da91f89dfe5056d4ffa9ce98095ce50393b13758630f846166b3598b47934c5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -679,7 +679,7 @@
             "generatedTestHash" : "9ad967d54aa61885d7e5fb67acab2890e6917742642daaff095bae62e08dcee8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -787,7 +787,7 @@
             "generatedTestHash" : "3af84150361a1aefb78fbdebccab996c29a1dab7e0d33e675a00d69f754130f7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -903,7 +903,7 @@
             "generatedTestHash" : "ad158c2fa6266ce27d12813d386f8dc9c72acd59babe09adb271337b4284b1fd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -1019,7 +1019,7 @@
             "generatedTestHash" : "352991f2b85709d3040e770e8475c7755cad460d3c70f089e6c7c2d01464a41c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -1135,7 +1135,7 @@
             "generatedTestHash" : "c233e05ab8ac3d1d35df9581e413d4ee31e6944a186c9b35395cc38f7b4262fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -1251,7 +1251,7 @@
             "generatedTestHash" : "eac7596a13fd4afd2d0df2e06c60cf40a8e994a950b0af88e387fd926aaf3d7a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [
@@ -1367,7 +1367,7 @@
             "generatedTestHash" : "d931c0f8d24d6a6df729a8faa9f9d3ad8f6523b9cb82f30f49bdbde2a4977028",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreate2/CREATE2_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE2_EOF1_FromEOFFiller.yml",
             "sourceHash" : "c806616ad23310c5776dc0edc9501867987d84caa93804bbbed3e0a35635e090"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "c758e28085296d7c0dbc01466cf4b111f65580d8fc72d7b6e5ba444cb0622785",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -128,7 +128,7 @@
             "generatedTestHash" : "aa65a69f6936254e95911bb5f9c5fbd66192c3f72a2556f7d539ec844c0f2acc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -243,7 +243,7 @@
             "generatedTestHash" : "dd97091df1c41279521de0e1dad6ae98d88486bafeefa1df8a4411ecdd382ced",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -351,7 +351,7 @@
             "generatedTestHash" : "9328c203416b27914e0f0f0ff224d1fe0f99af03652cf334f907be79a0ad1804",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -459,7 +459,7 @@
             "generatedTestHash" : "449a79c6c9cc3c48e7071d2aee5b19b05d1d7457aafc9b10d882709bf126010a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -575,7 +575,7 @@
             "generatedTestHash" : "d196faaa2fb99d2cc92a1bc3c74045b80500107491221cbe5faa7d8897488b95",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -683,7 +683,7 @@
             "generatedTestHash" : "52493fe13cb032f642f8cf256ee0a12d363cec00c09ea3703c24931ecccf5af8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -799,7 +799,7 @@
             "generatedTestHash" : "fd62ecea6cc466d5869d84ed854b0d9f956fb07e3cce306cd67041bb540cdc5d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -920,7 +920,7 @@
             "generatedTestHash" : "084e733e97c6867066c54e6feb376ddff7326093bca4b6c118dc954cd7b6c071",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1035,7 +1035,7 @@
             "generatedTestHash" : "1d332da2b49f2867c2e2647e29d6576df6fc35769b6e9d09a9560798ca2d3dc0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1143,7 +1143,7 @@
             "generatedTestHash" : "f675b02056dfa5c7129ac2b3d0ae7e273e92b2f501ecd596f14b0b1ae1fad753",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1264,7 +1264,7 @@
             "generatedTestHash" : "2760e3656883a764b7773883b64d058f2a8dad42109f63bb7d356a8fc831cc31",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1379,7 +1379,7 @@
             "generatedTestHash" : "59c00b8d1eae3049dc3425b31d3d7d417186a6d0fdc9605556f88ca04347b98b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1487,7 +1487,7 @@
             "generatedTestHash" : "844fe913a5f73fd7eddfecbe7d3404c332bb4405f7fa77af27b24e075bc0a959",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1608,7 +1608,7 @@
             "generatedTestHash" : "69feea2e93626d83637b93328b59b91f3676e0d548a335d67169dd383cd23643",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1723,7 +1723,7 @@
             "generatedTestHash" : "0be8e39f45d9c7514a5e0de60fc9787bcbe86c4c8ac11531e066d3bfdfc8dadf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1831,7 +1831,7 @@
             "generatedTestHash" : "b7c752a13b2fa840d5071a5cf5dc85d754ec10693fca74d89bd160332654e278",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -1939,7 +1939,7 @@
             "generatedTestHash" : "f36e92cf38c1f7485b41d6a089fadaad17ab8a0a047288335c79a51fd088dfb7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2055,7 +2055,7 @@
             "generatedTestHash" : "521da5875d6b50d2d8fec6d5d94106e5324a16929ac6e21cecf366a261628323",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2163,7 +2163,7 @@
             "generatedTestHash" : "e078352981ba36056734d18c6650a6e29257c2aafca21e40d1977ec1fccd2124",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2279,7 +2279,7 @@
             "generatedTestHash" : "6e9beac614191e35150b72c9a92e7563724a1f561c8ae645d5031f2fc865aca4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2387,7 +2387,7 @@
             "generatedTestHash" : "ed8683b16856d038cf1388778113a3c4ebaa4f213ef1925a382adb77d782c56c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2503,7 +2503,7 @@
             "generatedTestHash" : "8e81d5a62ac2495d106e31f428b42c064cb99d6cf2a40e32fbe278c742ddc48a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2611,7 +2611,7 @@
             "generatedTestHash" : "795d93265a26cc7faa73d44241668b0b20a3c8cd6097a11ace65f997db149ec2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2727,7 +2727,7 @@
             "generatedTestHash" : "2c33bd4c835a5eaa3782a12536e33e20379020ccfae6cee9efc0e019b6266f20",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2835,7 +2835,7 @@
             "generatedTestHash" : "9b6ece6afc6765ea95306df8f4f4447d89869c1536bfc13312a64a4e2587de7d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -2951,7 +2951,7 @@
             "generatedTestHash" : "4e7bb0d9523cad22213f7a4006d78f02125bda0d2c1eaa2e161a882ea2030019",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [
@@ -3059,7 +3059,7 @@
             "generatedTestHash" : "88cbc7c65ed1fb3325c4d485cf130ea4cba3e16cd816d568295fd69cc4b4220c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Filler.yml",
             "sourceHash" : "2a2d51b4d531da08373423ccb281c7cfe531c28d8d561330597dc8432481b831"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "525b54b0c7bd255d37bad1e73cebf3b72ef2613440d7fc267ce1487ff93f41e6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "b31238bc36dcac5cbb72566221def5ffe692aade2d1a3cbead23fcb9a457c9ee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -223,7 +223,7 @@
             "generatedTestHash" : "bdbf6390c9ec3417c636ee48388284e4f3621d5349990dca4079779e27c2cdf4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -331,7 +331,7 @@
             "generatedTestHash" : "44aa1397a1bbcb945f5b2381ab7e7795dbbc4d9b5c2f9a83dbb1f56dc8ac86dc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -439,7 +439,7 @@
             "generatedTestHash" : "958557ee666cf542a31758d69425f21e2dec68c03429cac16449b805eb8e41fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -547,7 +547,7 @@
             "generatedTestHash" : "4281dcdb94654f2e472f8e024ce7a2e08a91338dc855d8505eca919841de21cc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -655,7 +655,7 @@
             "generatedTestHash" : "9eb0397719cb3785800cd869846699a76b7b30f340bdfa9532924689be8fe165",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -763,7 +763,7 @@
             "generatedTestHash" : "3957bca75b04334ed0b44d4c5be928f95436bc11d2524202ed3393980cb6f0e8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -871,7 +871,7 @@
             "generatedTestHash" : "b85b1f3b772bc8fd185896909ddc8b060b229f997d8e20f6adbbb85c996ce2a0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -979,7 +979,7 @@
             "generatedTestHash" : "9ee4eab01c86dc3c3d7f1cc8d445ed7876850cf2773d052bf24384fba870b45e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1087,7 +1087,7 @@
             "generatedTestHash" : "0593b00bbf3e566b526b89656ee1dab170fa26a266a9b0e75dbf34b4f6b35c78",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1195,7 +1195,7 @@
             "generatedTestHash" : "a68226f06f1b7e72776d9e044aa705214de2fb9e895f876f6b2bee785f45b5a3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1303,7 +1303,7 @@
             "generatedTestHash" : "eaf764c0b75f7927377a90f7757e522876df113494e1caf0328bbd08cfacb41f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1411,7 +1411,7 @@
             "generatedTestHash" : "c0bab0ed08edef6d0952e6f08b257499dcf370c09df5868e15c618cd07acbdf3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1519,7 +1519,7 @@
             "generatedTestHash" : "c74ad44de0ffcc6353ff78be1fde3bac829ed223c8ba3dde039defa953ba5c8f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1627,7 +1627,7 @@
             "generatedTestHash" : "8dfe922f76817b78c0efc9367f924c620544ac592dc39fc9b94c755ce1846ee0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1735,7 +1735,7 @@
             "generatedTestHash" : "0b51c8b80c460466dbffc8bdd8ec7278718cf7157c029529f627843fbf025392",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1843,7 +1843,7 @@
             "generatedTestHash" : "fbad4a7a07ef9ad8a3d8b9cc1cf3a9468bfcc7d28ccac8bdde53e1baa9b5183d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -1951,7 +1951,7 @@
             "generatedTestHash" : "5d3e09fad9ef1f573238726e156a8152d7f0ecec86db4aa2fea4df17414af178",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2059,7 +2059,7 @@
             "generatedTestHash" : "3a3022882ff337773d34ead08cb1cf6f517a04f2cea640aa664dd57828f959b1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2167,7 +2167,7 @@
             "generatedTestHash" : "6f9014ee68d0df8780dbefbe23bd3e14472f92bd688716ee0ee6c87f91afd81e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2275,7 +2275,7 @@
             "generatedTestHash" : "34e619a503267b28ee0c7595e767f6bd04531c55e32da4d39453fc01c79d687a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2383,7 +2383,7 @@
             "generatedTestHash" : "1c31dd25066c5a7e8a40ddc6eb205d112e2bf7ed13a62b01b3f758fae03caec2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2491,7 +2491,7 @@
             "generatedTestHash" : "505f7e1de144a0847f00a0010a8ca02b19f73227177b74daba204e68d409db47",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2599,7 +2599,7 @@
             "generatedTestHash" : "afd69c2a9f2e0f278427131bcd494b7c70de5217e142d57df88b3719f7254908",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2707,7 +2707,7 @@
             "generatedTestHash" : "928717ac8c0e6f7fdb0bba4572fed48daf02e1e431fab2f51bd9d12570ff936f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2815,7 +2815,7 @@
             "generatedTestHash" : "f29773c519f16f8bf4724f6fa6e176ec5e8e0651beefda016c8559e796927f94",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -2923,7 +2923,7 @@
             "generatedTestHash" : "8a3185271e5148583ce9a889734f7106e36d0710f2936e75730f1232a2d4bc46",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3031,7 +3031,7 @@
             "generatedTestHash" : "a51edf575db0b6b52db54b2c5c578fb0b65d0419c846a01b054f1b26fe0efa92",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3139,7 +3139,7 @@
             "generatedTestHash" : "a98917239d70a6a2080265b72e97630fde3c07e0db0df761b030ba358bcfdafd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3247,7 +3247,7 @@
             "generatedTestHash" : "ff59fe15c48b7613a5e520f558e0c8d837a7fd0562b6b50df8ac7fd31c8efd68",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3355,7 +3355,7 @@
             "generatedTestHash" : "f474561e085ab2823d699b9b4ae9571a28f9fffeaff832d79d266ebfed8b84b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3463,7 +3463,7 @@
             "generatedTestHash" : "8242c132b34d0d34cb91bfb929f773430cdf4e00dc37763a9b2a1d2a2346ad74",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3571,7 +3571,7 @@
             "generatedTestHash" : "8f57db820b8790128dbf4b55a4150dfab9c9a422c402aabbbaed638560ff186f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3679,7 +3679,7 @@
             "generatedTestHash" : "e667c259a194a882048d26c2d31ff414ee9f3701d8b2136dbd5bab2c68e6dfbd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3787,7 +3787,7 @@
             "generatedTestHash" : "5c5df2f305df82d95b1ddbcd3219d330e7384120ab71e3ad055dfa632c7bcc46",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -3895,7 +3895,7 @@
             "generatedTestHash" : "f0913fb827b1504e45e4dff549d72ec9bc922eeb132c1a011918a07d0d51593f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4003,7 +4003,7 @@
             "generatedTestHash" : "f02492bf81cfb68d6d80ed9b5eeb5a82915081f985f6e1de199c8348a4df9e65",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4111,7 +4111,7 @@
             "generatedTestHash" : "de67bfcf8fe338cb208ae9bb9f3779582ed32a20f8613bcda86833c0912c9ef7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4219,7 +4219,7 @@
             "generatedTestHash" : "d108cfdc465a4617e5d5392dabdfde86d84631ab1581ad51a964a95a22785e41",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4327,7 +4327,7 @@
             "generatedTestHash" : "c8d6a3d9240738acf37cb24e06d9186d807868bbc8815c5fdcfe95146398edd9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4435,7 +4435,7 @@
             "generatedTestHash" : "47f058ac73b924e7bc13039c61268b50e9e3641ff7dd175ebb01fd1e672d83e5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4543,7 +4543,7 @@
             "generatedTestHash" : "3f933b87cba0af79f7c0c68994ab034c83830ce5ec23409fdefbe775a024b474",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4651,7 +4651,7 @@
             "generatedTestHash" : "1f4ba04651a198640acfafda8932980aaf48c22a457121a0bd2d95ed0dbfc7ec",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4759,7 +4759,7 @@
             "generatedTestHash" : "e87e15382836676ca31588bc8ef967465c4d22e3d00e79fc476f6bafa960375b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4867,7 +4867,7 @@
             "generatedTestHash" : "c1fead8abd98887c0897951ca6a2eb31854d43c4bdd2e274b9bc0098f6d797f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -4975,7 +4975,7 @@
             "generatedTestHash" : "37d103bed33d492dde2550323e13b241c4863a9357d1335c1acc3580ff3aea5f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5083,7 +5083,7 @@
             "generatedTestHash" : "62b0eb775f7c0e891dd38ba4f44b669b72343b1da8e33d0b8c241d3b1b99c7e5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5191,7 +5191,7 @@
             "generatedTestHash" : "1af172f091ba04d27405fdf71d6c614bf9c17a455e5939127d8d39ad49df1240",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5299,7 +5299,7 @@
             "generatedTestHash" : "6ca41f6716a16afc9487adf95ed5c981e53637a8eac6428b8c948adab792262f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5407,7 +5407,7 @@
             "generatedTestHash" : "c12cc515ea1b227050b1c4da7df04330b33ab713eed131ea1f31cc7ca4ec3606",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5515,7 +5515,7 @@
             "generatedTestHash" : "e5106bcab9a9768db239dff98b06ebca5bae1f03bd7c2c85691d1fdc4f90a50e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5623,7 +5623,7 @@
             "generatedTestHash" : "9842b450f2b1d48717a18ac3be55da949b390f8334701e2da212b6bab37ea239",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5731,7 +5731,7 @@
             "generatedTestHash" : "61029e86cb85ba8c18f41ded9e3e5bb1ef0fbe18f5f2f5d5ec9443d6530894a9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5839,7 +5839,7 @@
             "generatedTestHash" : "ef00a2e8475106f45f9a1a83998824b1d95220fd599b51eb90beee935ccc3989",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -5947,7 +5947,7 @@
             "generatedTestHash" : "ed4deeb4a97d88fb0e339051b94c1c27b5943abd173de96f76750e85550f51fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6055,7 +6055,7 @@
             "generatedTestHash" : "74a4e6144b6615327c58b3bae7e90d86857d2da8677933faccf2370725164832",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6163,7 +6163,7 @@
             "generatedTestHash" : "431a1124ddc0d0484b03ec91f45fea0717496dd48b951d1bc1ffdabc4326517f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6271,7 +6271,7 @@
             "generatedTestHash" : "9513f375ae54d24988f1ae6e49861e02605502dde6e442579de5c08ec4f94922",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6379,7 +6379,7 @@
             "generatedTestHash" : "f6cc997081eb35859f4eb38ba311c3d2ec05e68144dd3d420fe0e7ce31287a2a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6487,7 +6487,7 @@
             "generatedTestHash" : "103f2b79f0dbce45738a3e471604816098eac53641c4174ac49ed42eca93774f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6595,7 +6595,7 @@
             "generatedTestHash" : "64f3296933ba1e3d6491a29387c3781b1c1226ba658cc062b0855b478985d0b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6703,7 +6703,7 @@
             "generatedTestHash" : "362c31ab8b6cf3ca922c169d0c8e300b83ab7a1a63fe5975ef875bb5e19e947c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6811,7 +6811,7 @@
             "generatedTestHash" : "4474a19f34fb6108c696f505fa845722a2840f4e6c2c1c13135e3abf9c4df9c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -6919,7 +6919,7 @@
             "generatedTestHash" : "33baece3966715a8b4572b0128f3937ec04f75e5ec5c0081df730f231bfe00ed",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7027,7 +7027,7 @@
             "generatedTestHash" : "ab2b208820e935c42971ecd0d5e88fbda1d59d2f4c66aee9c6e1700730bc2592",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7135,7 +7135,7 @@
             "generatedTestHash" : "47a48bc9373feaee5a3e89f5a5025810d918e9b6854efd4475b7e76cdf7f5c36",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7243,7 +7243,7 @@
             "generatedTestHash" : "7c2384444626467d11a84cf574c025f9ef8af488bdf053193712177e56c89b0d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7351,7 +7351,7 @@
             "generatedTestHash" : "66c5e9349a9d54d4c456fdcbe8167d12c2eb88ba780885f5cd074f7a394b49bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7459,7 +7459,7 @@
             "generatedTestHash" : "f54bfadd74455acd7392e3856bef7b7693ffa2f44b239e2442c69a5585720205",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7567,7 +7567,7 @@
             "generatedTestHash" : "096121fb0f7c226dc19d9c9bb2aba99feb2e67f15275e8591b02104fd041dafc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7675,7 +7675,7 @@
             "generatedTestHash" : "126697abefdc1552ab7d78c8a72d714cd857a5aeb97ad3c6848bd0f5923801be",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7783,7 +7783,7 @@
             "generatedTestHash" : "8344814a0f0e21246a9597288f093e9756f67a4b1891de20302cb3000aae8f35",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7891,7 +7891,7 @@
             "generatedTestHash" : "7dbf6264bdc3dc731d9df0b8c5a8fcdb1e13f72d228832d0e9656bf2511e8c69",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -7999,7 +7999,7 @@
             "generatedTestHash" : "25b969a60450dd0c0cee30d06816929b2b8816660836429ef9b7b3bf3b9a0494",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8107,7 +8107,7 @@
             "generatedTestHash" : "292c7241c09b9a6028cd2347b41f01bb00393f94bd0848dcdd02e774584ea9ac",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8215,7 +8215,7 @@
             "generatedTestHash" : "6fda69eae3504f84215a42f08710a81e15e21d9abdfe9d2be6883ffe42d82acc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8323,7 +8323,7 @@
             "generatedTestHash" : "d20f4a5a6fb4a994e6332e11949de5370aa187c6dd0589a0e27f82794286011d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8431,7 +8431,7 @@
             "generatedTestHash" : "dde5cc78d8d27137ec669a180ea06c2502e2329a2280157bb5e0ed012324c191",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8539,7 +8539,7 @@
             "generatedTestHash" : "9258136a2348a9a7f714e4cd42b0b184e6807f7b316ac91272bf7113ddbd75c3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8647,7 +8647,7 @@
             "generatedTestHash" : "221c66db7fa5442fdbd8cc2b6cf13919d75f9a1f52e48697ec72ceabfc86740e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8755,7 +8755,7 @@
             "generatedTestHash" : "b59f4514f90ead31a7d8b77fbfd6110a6fba8f3cb6c9d68ba88f2478ad9562e3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8863,7 +8863,7 @@
             "generatedTestHash" : "6e6fb82b64625e5c9d980c910b8e0e54004c274c623c340d90d623b486af0a39",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -8971,7 +8971,7 @@
             "generatedTestHash" : "2eecb24a1e5d065beb3033eee4338b0b2ed7bd05bf7f7be1e26237ecc3e898c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9079,7 +9079,7 @@
             "generatedTestHash" : "cff16c1c0437ba81d41287f3b169654395f9cdb8bd3e2b920dbd5474192da353",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9187,7 +9187,7 @@
             "generatedTestHash" : "bb9e550a2950d80df3023126c8381a0f0fb42e094525c49097098c20f211095b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9295,7 +9295,7 @@
             "generatedTestHash" : "578fbdc65e6f9e99863dc241848a2f3f71330222f8933556bda15ee342fd4fdb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9403,7 +9403,7 @@
             "generatedTestHash" : "9442bc8d0984861f2c24f4a589be0fa97760ce4cd5bdca776ea99d504c936d57",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9511,7 +9511,7 @@
             "generatedTestHash" : "cb9e34f8a46df69d37d29fab978cfdc19db8484454bedf1ba419de4387cfe050",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9619,7 +9619,7 @@
             "generatedTestHash" : "678d17c000ec5625c3a817fdacbbaf0520fcec8c55094970649ad450ad673331",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9727,7 +9727,7 @@
             "generatedTestHash" : "df7dabcbd1d3d6a53a37c04b759557d8175809dd42dee02742a725b8ea151b92",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9835,7 +9835,7 @@
             "generatedTestHash" : "d6e8cf10194c573cf7b45b2268c5990a388db59caec2964592a713524e33229c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -9943,7 +9943,7 @@
             "generatedTestHash" : "d984c4db7fd633f170393eeb75942119d9b0cd2dd4410c0601b4f66e02559492",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10051,7 +10051,7 @@
             "generatedTestHash" : "1e6e27267d549c33eecfd66f8fa141409e9ad5d3cb5444460e1593555c68f507",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10159,7 +10159,7 @@
             "generatedTestHash" : "5b8f92556e871f72ea7a8d5439969d67838622038b7e3a568dcd26ddf057cdba",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10267,7 +10267,7 @@
             "generatedTestHash" : "1c07e0b1f96c17dd59a45ad601439215396f418ba13e596c6f484066f1e3dd70",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10375,7 +10375,7 @@
             "generatedTestHash" : "cc470ea4bb6bc73f91d2245e5968b68d2866ca487309fe10f99478ec4f8b89e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10483,7 +10483,7 @@
             "generatedTestHash" : "f83c56e882a98dddf4712c9af0209ca2a94456f1b55db3917b9ca1ee12332e6a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10591,7 +10591,7 @@
             "generatedTestHash" : "83d39f748d3c6b3237f69a18921570d147d730ce6884733731f83f5f9ea1e09e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10699,7 +10699,7 @@
             "generatedTestHash" : "dd8ed2cdb1f99b84e81026476b468eef985de7f25be66f6cdc69878b1f2ec0af",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10807,7 +10807,7 @@
             "generatedTestHash" : "082fdb67cc2a0066772c9d88232ff7d2fe42e66cad1b075dcbeba0f6b05a5cd4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -10915,7 +10915,7 @@
             "generatedTestHash" : "a3bdbf49eae4e63fbe57a7bb2e8d9b4ade3fa3ae44bb627e33af5a309307febb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11023,7 +11023,7 @@
             "generatedTestHash" : "69249bf6fdb045d3ef3a4e83698cd0aa8a6bae724426b0e9a22aab17eb261acb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11131,7 +11131,7 @@
             "generatedTestHash" : "b4a9146654caaad787c4e9dfd4b1426e3d23e551324edebcc7c4723fdc3f5521",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11239,7 +11239,7 @@
             "generatedTestHash" : "bc0b80f476449cb33405d4d184edef36301f5dbcea63c489893aa24481cee715",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11347,7 +11347,7 @@
             "generatedTestHash" : "963c2dfd4eefc11b949152f238912b991093894e3ea9410810234d5a1d98ebde",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11455,7 +11455,7 @@
             "generatedTestHash" : "738c8491e8f5964168e35228a348fa56cf3846ff3fb33e431b5ea9a3ae338ad1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11563,7 +11563,7 @@
             "generatedTestHash" : "23aef8e2974d71f124b40d061adc271ea58a52511c8231d24425137b9d759d77",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11671,7 +11671,7 @@
             "generatedTestHash" : "924042b5f902c84645599f84f1cdf5cdfdf1b04a23ba9c755501fb6c31b0817d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11779,7 +11779,7 @@
             "generatedTestHash" : "1c82812f95fa9877d96f81ea9b735c45b984971b71e62d9af3bc45f7ac1e958d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11887,7 +11887,7 @@
             "generatedTestHash" : "7105268b4b68bbdd15f83a370520d76a87166506d8517d0f89b14f2fbaaa1a8f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -11995,7 +11995,7 @@
             "generatedTestHash" : "52acb1f9f7d9cacfa4bfa2d7a2b6356b6927beb01649494041c1a8931658eb12",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12103,7 +12103,7 @@
             "generatedTestHash" : "156309fff07891535d4186d0f65c8c8f7de8358f78c5978a3d92b541d581033a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12211,7 +12211,7 @@
             "generatedTestHash" : "e0ade726e5ec1dc7377429451d1114814fc7a9149ba1ee38ab3a23ae5c1a01d7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12319,7 +12319,7 @@
             "generatedTestHash" : "a252456b04fe618ccb46158c3fc70306077544f02d9ba67acace338dce046978",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12427,7 +12427,7 @@
             "generatedTestHash" : "b56e060f69da0c1f662cf37175ad9d2badde95e93c81afe304d5bc3e8e93bef1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12535,7 +12535,7 @@
             "generatedTestHash" : "1c5c4b0339d355d63f8ba5f58f8eb095484f6c3e8d7ae44683c475ead11d9b28",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12643,7 +12643,7 @@
             "generatedTestHash" : "05fbe9a4c22ee50dc6a6993083648cc7b16e023293836a79314d2c7f62c3ce35",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12751,7 +12751,7 @@
             "generatedTestHash" : "616e0273a427b1c0ca50b03e253b4a275fce9949b2b4f793bb1541ca444b3803",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12859,7 +12859,7 @@
             "generatedTestHash" : "d81c5698cc9eaff30bee193deacd2673c1700e293e19934a3df33b7aae2930a8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -12967,7 +12967,7 @@
             "generatedTestHash" : "d1ad2d4beb9153f2d4bf17d2bf8c1ac6f9e3be626b258d2c1e1c8dad12c3d4f9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13075,7 +13075,7 @@
             "generatedTestHash" : "0f802d7c92b0164af1c251e2366c2be6de16126442a4dcd785ca30dc2a8cd7ce",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13183,7 +13183,7 @@
             "generatedTestHash" : "089ce0d461ec6b0a88533d3a796a0bdd4bfc6d3893cf24e207a8199c4895dcd9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13291,7 +13291,7 @@
             "generatedTestHash" : "4b862ecafe2d0fc4bfbac655c388b5f355dcb56ffc472d7fdee4afdf53244b5f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13399,7 +13399,7 @@
             "generatedTestHash" : "3d1967199b6b0655ab788e8449e84c03e3b80075183f506244a6e7c170aaf62e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13507,7 +13507,7 @@
             "generatedTestHash" : "b9845e57d765d1545760e55092fcd0cd3222aa2cb514e4e802bd4f8ddacc9ffa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13615,7 +13615,7 @@
             "generatedTestHash" : "5afd8fc578126391b0d26cf55bca1a84f315413d940c0561d4a8e3bff17d75d6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13723,7 +13723,7 @@
             "generatedTestHash" : "c6d7f2d989db81914b371e1b78bf19c78336c07277effa1e99a4aecada2f2b20",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13831,7 +13831,7 @@
             "generatedTestHash" : "b1150bbb70c52f312aaf188a38e24bdf23e0252bb522922168a016df3a677b92",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -13939,7 +13939,7 @@
             "generatedTestHash" : "bab69f6b07c014827a568a07130432f6a27ec32ba895b980892a094a02ad88ac",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14047,7 +14047,7 @@
             "generatedTestHash" : "c7a70784138f25f5c4110f9fe0cdd243f5ea003fa404bae6794dea44aba5e6f9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14155,7 +14155,7 @@
             "generatedTestHash" : "17e0127d08a1bba45796f722db5d823e8118122ae72bbf3438a3029251ddb407",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14263,7 +14263,7 @@
             "generatedTestHash" : "f458f707d691cfa39a52ff737e63a33724f742b9b09613ff835d6b1eca382533",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14371,7 +14371,7 @@
             "generatedTestHash" : "bc658893db62dc5a823d98d46734d4a2111fea0c2361b6142dca3c2552c372ab",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14479,7 +14479,7 @@
             "generatedTestHash" : "993005bc994c27da808658720e51fd45e216b5d252d8beed9be2a88fd53e2161",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14587,7 +14587,7 @@
             "generatedTestHash" : "91fd1f31111c23925a3b4435af6b9f8424a16b76dc396e3a7a8796afcad95ed7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14695,7 +14695,7 @@
             "generatedTestHash" : "0e97ef4931f6d073694938d629b0b4290cb3447525d80b12967104d4af8a43bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14803,7 +14803,7 @@
             "generatedTestHash" : "64bb450682265aa4e18f024783060c06cfbcb3d2041bb741467aa613fd29fa7d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -14911,7 +14911,7 @@
             "generatedTestHash" : "6927f4bd7ed50ba1dd45ed88628a7e15f48af8e74b2d5c49db8cf2578b259739",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15019,7 +15019,7 @@
             "generatedTestHash" : "376768e40022bd435df066004dcd6272008bd74f122a8e77c68c6c66f8ea94f5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15127,7 +15127,7 @@
             "generatedTestHash" : "77c71770694ba22a337761f51002b838af7b7d3063ce1c7f1a2f078f355f3d63",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15235,7 +15235,7 @@
             "generatedTestHash" : "6ae6d4cb554f23c70a30281a5b7c88d68a06e1ac4407dd31a5022d92bc5e2fcb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15343,7 +15343,7 @@
             "generatedTestHash" : "d6bd5b0b322240b6638e0abfe2dd1aefac4d184129fafbba1780380b05421d1e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15451,7 +15451,7 @@
             "generatedTestHash" : "ef7a92b93f0cc6c8076bb644871f3d01b68bd410f48bec001e5492082f92f198",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15559,7 +15559,7 @@
             "generatedTestHash" : "e615e44187cd246298dba195842d60ab6c1a154f006a9052b5560d9919752d6a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15667,7 +15667,7 @@
             "generatedTestHash" : "cb36ea5a89cb069b4cf13730f51443b72518d1cfa944336989e4d759f292d910",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15775,7 +15775,7 @@
             "generatedTestHash" : "61acada627077d7dc6d1f73142be4aa8339b0dd77b0a3b3b1be9a2c069129598",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15883,7 +15883,7 @@
             "generatedTestHash" : "242e5ba80dc6ae483544ad946c569977d1596f2b4a83a8d94d761a3f1175a32b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -15991,7 +15991,7 @@
             "generatedTestHash" : "b5029953a88b5877e5eedf336190fae584c9a30cdac80b2048d74509302179dd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16099,7 +16099,7 @@
             "generatedTestHash" : "6685000fe4f59804739ad3aaeade6a68ebb32de9470eb9b636dfa9900b209d68",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16207,7 +16207,7 @@
             "generatedTestHash" : "049b294d792ef16c71bc7eeea8677fc1d35f84ee76b4be24650c104a7a4ec9e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16315,7 +16315,7 @@
             "generatedTestHash" : "3074b2cec57ff5071656a2652f0177dacc99ed8c2ab4ace1621ebb1be25d9b4d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16423,7 +16423,7 @@
             "generatedTestHash" : "a2c016a943b896e56098fb60fcd8df024593e985d87e28bcaaa14f433c39bb81",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16531,7 +16531,7 @@
             "generatedTestHash" : "cf5cd6d693e18d8f006dc2e56b1998f06ba1565c21bf21a9c0a92f4c98a74c39",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16639,7 +16639,7 @@
             "generatedTestHash" : "da90bcc912ffaa0c7f7e0a9c5df8f9432280eac7fa187c77e7728a8bcbc3610e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16747,7 +16747,7 @@
             "generatedTestHash" : "badea822cbfaec601140ed8859812c1f1916971eeef4198893d3537553d0d789",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16855,7 +16855,7 @@
             "generatedTestHash" : "518ead999a668e115b6bd0cd718b6c2e7bdcea718a437f9cf0ea0a3f40a5296e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -16963,7 +16963,7 @@
             "generatedTestHash" : "e1900bdd34a1d1c49280739318c69b04e34b6fa79b5dd66963bae2fe5ccfa96b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17071,7 +17071,7 @@
             "generatedTestHash" : "92721ab31fd202b9ed25190e88107382f7bf6961442dacc815fae17e21fec048",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17179,7 +17179,7 @@
             "generatedTestHash" : "beac6c66313c0bea50734f8e4029bb0037165a9138ea72ec5670cc5931c99af8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17287,7 +17287,7 @@
             "generatedTestHash" : "a397a9464e9c7284c1f3f533813f5123f9c32eea234bdc5d6e4a04721c29fd4a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17395,7 +17395,7 @@
             "generatedTestHash" : "4402a07233936069cd8182d68230b69bd57ad4d44754e26d1cfadc3485c5d3f7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17503,7 +17503,7 @@
             "generatedTestHash" : "1ba56a46e0f6ba1df97381eec5203e930af6651917da7534552fbaccdaa699ae",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17611,7 +17611,7 @@
             "generatedTestHash" : "9ed469b7be63dc0e5fa38bfcf5b3b82dfd119bb69fee327631b8f6fbd4a211b3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17719,7 +17719,7 @@
             "generatedTestHash" : "1a1b5ee43e49f3a70ad2894efa0118b3d4e33139b01e52612e90a9b77267fa22",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17827,7 +17827,7 @@
             "generatedTestHash" : "dc8d8a73241d654822baf960406c6d89dd5f8d627a2ccd48f75b964932dd9e78",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -17935,7 +17935,7 @@
             "generatedTestHash" : "a462aae394b34d22d2c6834758f85186dc3e2f65d287823454b59a89c906052f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18043,7 +18043,7 @@
             "generatedTestHash" : "b159495bff41d973c3bc00f6da173b2f63e80cc737cc993957a337e435d3b1af",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18151,7 +18151,7 @@
             "generatedTestHash" : "b22fcf1b80f25aa69c892b3746d1375af3c7c6b5545b9dffa1e22db49456337a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18259,7 +18259,7 @@
             "generatedTestHash" : "6d18d5807951a0afd219991f78450d69103336a453146c7cbad23d497929a03e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18367,7 +18367,7 @@
             "generatedTestHash" : "49cbdfe401327a1e122e7bfb77c31fd5c1b9bda78cf1722b24df4e37c0ba4538",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18475,7 +18475,7 @@
             "generatedTestHash" : "bcb2a7a97cc3e1feafe192930986df2f62bd20c188d6b9e695a5769b8440c487",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18583,7 +18583,7 @@
             "generatedTestHash" : "671d61c50e2c19bd0595ee7f395ee345688ef6c85da2661fa8e1a9d09161cd56",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18691,7 +18691,7 @@
             "generatedTestHash" : "841da61188738cf044119accf3657f6910eb99f9d48c23b7256987039522aab8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18799,7 +18799,7 @@
             "generatedTestHash" : "3c122d7a0b0f6b2bdbc978c051b9c7cf6ef03bf9832494e2cfb473b7b5fe6f23",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -18907,7 +18907,7 @@
             "generatedTestHash" : "e40c813a9d4173a32f7fddf4c599d15ce0227943205f16b57a92aa902d5ae2ef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19015,7 +19015,7 @@
             "generatedTestHash" : "c316139a2ee736a744252f269cb8e488253a34b72c6429d0ecec934a3eddc536",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19123,7 +19123,7 @@
             "generatedTestHash" : "784fda5ce4d0521f2736c5b58d4ba436eb85f22d2c48f8c1660eece14e6947b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19231,7 +19231,7 @@
             "generatedTestHash" : "b1430a7ddf69d8b30baf79fcc3180ad897455775355ea594f20e5c55a69c9b61",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19339,7 +19339,7 @@
             "generatedTestHash" : "ea39e75a66d97c2b184b447ebef9882c3805380722b0219bbb71e291b2d0b104",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19447,7 +19447,7 @@
             "generatedTestHash" : "33286454f1e513c9e8c42c49a9af88acca18e9dc68fff528b993b11333df1f4c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19555,7 +19555,7 @@
             "generatedTestHash" : "57eb7722f01899f324d07fbe28246d4adc5ac66855298da95708559f5331bd3d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19663,7 +19663,7 @@
             "generatedTestHash" : "ea9d12b7ddd6cfec1667dbf51cb0a540f837ef364982acb42cc4f0c615a7aa2c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19771,7 +19771,7 @@
             "generatedTestHash" : "e42daf57489e2169c4780fc76c70ffffbbdef9fd3c435f5f2de22d102671b525",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19879,7 +19879,7 @@
             "generatedTestHash" : "e7514cdf79668641eb1058cb0bb2ee1820bc7b00e6ddb1218edff0e7d5789912",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -19987,7 +19987,7 @@
             "generatedTestHash" : "e88946ede2cbf4d0ee18b9a8762e75e6bbcc06ab8fc4a16df6f41711dc6111f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20095,7 +20095,7 @@
             "generatedTestHash" : "51772c263956e9c064fe7f73907b90925c6c2f12e20ca0f581590813b8a6dd9f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20203,7 +20203,7 @@
             "generatedTestHash" : "fa502e35501f014d4b96a16bb759b091aa5007b8978de231a534095143e98a60",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20311,7 +20311,7 @@
             "generatedTestHash" : "9c6d83e0110f7a6a491fe09a00f577cf610757cd31e3d8707f26b20685273711",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20419,7 +20419,7 @@
             "generatedTestHash" : "c52231851c1b505b9ac52a9680b0aa2220b52d6a98dcf177565e07656669f569",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20527,7 +20527,7 @@
             "generatedTestHash" : "c3a179274acbf290031285fe3c65d913eca705f1e55c67b3434af345c93d9395",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20635,7 +20635,7 @@
             "generatedTestHash" : "ccd405d558f6a3543069bfbfa4dc56113d56ab723c3a63aea627f0da2e0dc5b3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20743,7 +20743,7 @@
             "generatedTestHash" : "bcde132abf40e098c6e2cf958d02f83e455dec871246c93504caa23e7d3fcb43",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20851,7 +20851,7 @@
             "generatedTestHash" : "fb79e2fd731a5123630dcb69b3f04833ca6635373f064a115aea6e5d77081f6e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -20959,7 +20959,7 @@
             "generatedTestHash" : "7d6029808ac6b3c2dfca3f0822fd5ded64187d15a5c0dd757c6827d44c3d445d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21067,7 +21067,7 @@
             "generatedTestHash" : "f62f1563ba1ca28474e4c038dfc4bc4ce42e75b7176e976435c9aa31bffacfe8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21175,7 +21175,7 @@
             "generatedTestHash" : "6141198b6df951cabb7d2fea0ba4ddbee949e2844633dc0cd7c759d5e8a004b6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21283,7 +21283,7 @@
             "generatedTestHash" : "a518811d79612bdd0d9ace84f4a410704c2ab7e3952a7fc69172b38fd98779b3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21391,7 +21391,7 @@
             "generatedTestHash" : "703c12b2fd9e63d539c2341d1c1ebd77279212ab022727bea184c1b59bf77561",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21499,7 +21499,7 @@
             "generatedTestHash" : "366287286de1a0d722cf451044345eabb35b0779a2ae7e1bb1c465ca753b61b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21607,7 +21607,7 @@
             "generatedTestHash" : "9c423d6a367dab7cf7e05b4aa1fea23d875091cd7fd68351acdb2541c5e7271e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21715,7 +21715,7 @@
             "generatedTestHash" : "f6770ac77fe3d7d835339356a8ed67a6eff9eaec38aed88f79bc478d668b70ec",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21823,7 +21823,7 @@
             "generatedTestHash" : "0edb375a0824546d49ef1e1383df7133083c60df88c5559755012a95211ffdc6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -21931,7 +21931,7 @@
             "generatedTestHash" : "d1efab3a7d53caf1862309d1b0d42671196e8fdee0cd0c4575a933efbc1cea00",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22039,7 +22039,7 @@
             "generatedTestHash" : "faf4143bff7096007fd00fac30527f491ab63f3211dea52e24762457685d165f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22147,7 +22147,7 @@
             "generatedTestHash" : "d4b8044e7144435dc9cd76e3c2c4d7f9a3c7a14ea04b2bdde2e6504e981a5a78",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22255,7 +22255,7 @@
             "generatedTestHash" : "3b5f48b5dfa457c0fe812427ea017fde50d1e6f3678c0bb1a3ea0f2ac341066d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22363,7 +22363,7 @@
             "generatedTestHash" : "94b1c35d0850c9ed846492d0d94386a2fe52e58d8a773600a03d53bec8f9cd6d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22471,7 +22471,7 @@
             "generatedTestHash" : "bb2081d1f91e63d775996ac9616c5f2f7291b9d77353d1c773d19ffaeab780ba",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22579,7 +22579,7 @@
             "generatedTestHash" : "4caf43069611e0ad52d331ce3365696ff9fa3ce19ac991ae5798bb34971205a2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22687,7 +22687,7 @@
             "generatedTestHash" : "c6b6a7c65097a01c555d7fa70afe292780192502a34664ee686d353b353df3d4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22795,7 +22795,7 @@
             "generatedTestHash" : "ac43aee5ecb9cccbfac9aa0f11f217ee0099008753b0eec98adbcc4b1606017f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -22903,7 +22903,7 @@
             "generatedTestHash" : "bbbf11b1365c0eeed585bf7a597c113fb812a9bb9056be9f1f703a76a3e42555",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23011,7 +23011,7 @@
             "generatedTestHash" : "db3918e58342d17aa6fdf0633fb8ef3fa4480a899092165f36ef3d1a1ab3e6e7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23119,7 +23119,7 @@
             "generatedTestHash" : "a517f1913a25cc8d429abef76f32fb0db0ff049f623ab2a3ec9fb60d0477937c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23227,7 +23227,7 @@
             "generatedTestHash" : "af4975b30f685dcf6913e09db89d7b093d2097e3583b2e3d5e7825da3de19675",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23335,7 +23335,7 @@
             "generatedTestHash" : "51d40150fdd4fd11d19a63e61207968f758e8e636d6ea024fc42c8c1832118a2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23443,7 +23443,7 @@
             "generatedTestHash" : "bbc73b513b1e400404edca4638b1def4ddf7096903a26774618f62fd7f026e48",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23551,7 +23551,7 @@
             "generatedTestHash" : "4d12b8d696ded4a0b6d625791c33b01ef31768982948d1c42b805fd11f8c96fb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23659,7 +23659,7 @@
             "generatedTestHash" : "203639fa0e5dd2346030519b2ef9f1032c4657b402c4df0d0a41e8abe7020fc1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23767,7 +23767,7 @@
             "generatedTestHash" : "e795fa1e90ec40ae10bcefb81549ff43a7e7a0cadbf68bd0a277919464415dc7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23875,7 +23875,7 @@
             "generatedTestHash" : "66cfa11d9a1ceb48f67ef5e44030db162143f18fc4b5287bcbf8615d9debfaff",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -23983,7 +23983,7 @@
             "generatedTestHash" : "c622b50a3aa0111ea34427f6c89d19ac601f1859d1acb0a361155849a6b5c57b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -24091,7 +24091,7 @@
             "generatedTestHash" : "06b08a8ed9e8fe3ef4c6bf5612138c609a454f62ba1bd76be8d8ed604e655469",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -24199,7 +24199,7 @@
             "generatedTestHash" : "2f6ed073205afbbd2a9ea1da1ae75253255e5a7d69b2ec354e02b844556dfd2e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -24307,7 +24307,7 @@
             "generatedTestHash" : "79cc9bacca244cd4a8ec6e4d18e8dec7b4c6568fe720508a6044ba0cab005bd8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -24415,7 +24415,7 @@
             "generatedTestHash" : "d61b8b4ef7781f5f0069ef10838be0ffde95c041f3aa9fc30fb0b82725aad4d3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [
@@ -24523,7 +24523,7 @@
             "generatedTestHash" : "78b3ee166d54ce24a6f320aa9d182cc0797875b28cb7969ca0623b25a816f4e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1InvalidFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1InvalidFiller.yml",
             "sourceHash" : "061771c9d5a8f31a4f2d4df996acbde054f22951b8a99a19b6bff91ee7c34d21"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid_FromEOF.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid_FromEOF.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "6c004a6785677e153245449090228fbe757974ccf03d863b54fbe581277f173f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "5e8323d1496bf7f6d5dcb075ca8dc7cd918510f128757ce60bfd4fc62dc3fd4c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -223,7 +223,7 @@
             "generatedTestHash" : "ac0efd26aa8808593c3fe1bd5105f52a06685f615803fbad72cdf8164ee5d063",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -331,7 +331,7 @@
             "generatedTestHash" : "e12d2dae3a2ec28f8f5945a04ad884a67365f1bd4c6e18fd57f53764433927e2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -439,7 +439,7 @@
             "generatedTestHash" : "09bf0d1e0e37f085d6d2e50c0449a5c4dc91bd8f4e1e64ace87ea35a3b7d2cf6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -547,7 +547,7 @@
             "generatedTestHash" : "dbcdb680d9afc72656a7fe07ff281d05b1b07c3aa46329c831e7f08a5f3d9b8c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -655,7 +655,7 @@
             "generatedTestHash" : "cca610236048aa075ccab3a1b708f21e322d2165c7e9480650313bb9782709fd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -763,7 +763,7 @@
             "generatedTestHash" : "2d55e64fcba5a46a96df88476cb215e78a28056d0a24de1203be800c73cc0000",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -871,7 +871,7 @@
             "generatedTestHash" : "3095e4c2950604155ce6d94ef5917d86fe5d14ddabd64269085d5271df7f7c98",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -979,7 +979,7 @@
             "generatedTestHash" : "0b33b2016a7718f41938f0c40cfe38533ea16ac5ad760faab4b7316ca93eb1f1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1087,7 +1087,7 @@
             "generatedTestHash" : "611cc5dbbc7c2a99547013d686cc02544fb071a58d8650b7096113bf8481a5e4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1195,7 +1195,7 @@
             "generatedTestHash" : "05bce9105c1cef1c43c25f6f4f591b38f639da4c9de70c1ee928c4af5ada2eeb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1303,7 +1303,7 @@
             "generatedTestHash" : "a79aa5f147201666f6759ad424215a5baf2c69a31e8c0568d5bd7da092cb7775",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1411,7 +1411,7 @@
             "generatedTestHash" : "423d61172ab9560fbae394343c2a4084288b8cc6c1fce496a8c25baebebfbfcd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1519,7 +1519,7 @@
             "generatedTestHash" : "e6a0551b72be8491574f862ac1fae33db6f62500d2db58c73bf8720716166bb0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1627,7 +1627,7 @@
             "generatedTestHash" : "5e2b5cfb85a5413eb00d6e654cbbef15924833ff70775f92eef7288ba823c382",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1735,7 +1735,7 @@
             "generatedTestHash" : "c2d3d326451faa9afd76cff9fbe7e5bcd722f8b51d90b0e20111f52baaba11a7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1843,7 +1843,7 @@
             "generatedTestHash" : "6f5fa762571ef8b8775929f23284880551c7ede33ad0127bb35c2b42217c4ef0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -1951,7 +1951,7 @@
             "generatedTestHash" : "d317ef9d7b9dbeada6e67afdf70e3e2566cdbb4cd3b1e3b6930fd2691eefdc94",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2059,7 +2059,7 @@
             "generatedTestHash" : "951c5c286405fbda45cbddd2912f3adc7579932e8f8584bee7d9de5ee881debc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2167,7 +2167,7 @@
             "generatedTestHash" : "01ae8ac6d279f3448be57b2840046cd68526f6e67d46b5e8f039ebb6a778b306",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2275,7 +2275,7 @@
             "generatedTestHash" : "81e548bdcc9acee116cb03d96f0f5427822d15bb0035a25a272215b014720079",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2383,7 +2383,7 @@
             "generatedTestHash" : "f9c81f2ca93ddcfa964c59e0e0373d480cb530e5564448a96d576fac43475ff0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2491,7 +2491,7 @@
             "generatedTestHash" : "c41d7a20f2fdcfd7162decedc60224a835312bb9884e528e0a7d2cd85b3a570a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2599,7 +2599,7 @@
             "generatedTestHash" : "62ccc9045c3d7b22bfd817f457ca41b39b0bde542317bd2274ba244f176e7366",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2707,7 +2707,7 @@
             "generatedTestHash" : "246f381b45137dbe890b08c3242717dfe6239f65e338bdc022fa7271a36d18e1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2815,7 +2815,7 @@
             "generatedTestHash" : "6dc4335289d52dcf72438370d0f38fb98c7c392be163008edbc78bcfec5a2a49",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -2923,7 +2923,7 @@
             "generatedTestHash" : "59baec674fd786c355d4447ed2abbe11e1bebde03ff9fbf3ff485083672badbf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3031,7 +3031,7 @@
             "generatedTestHash" : "debf851ad1bdd4dc1756dedc0f65d8ed4c8573edb3b215e4a3a8ad416c287c06",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3139,7 +3139,7 @@
             "generatedTestHash" : "fd2e719baf290ca90aa17f34db0c8030a6077b629aa23319116103fb8be1a249",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3247,7 +3247,7 @@
             "generatedTestHash" : "94f1be0f49f79ed8ed50adaa698695d44d5e55abe9975aa5344384af109f7981",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3355,7 +3355,7 @@
             "generatedTestHash" : "b68180c5ad6b99b2324dd1eae7649dafbc62a75b1914e62c039054df5f060139",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3463,7 +3463,7 @@
             "generatedTestHash" : "9cd66e4a3340ebc074ceed33d05ad54564089cfbf40916cfcb9aad3a0865aac3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3571,7 +3571,7 @@
             "generatedTestHash" : "7d6459357ef469e17a15897e67abc32e9b179cbbc90bb675d295fe39d009b561",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3679,7 +3679,7 @@
             "generatedTestHash" : "9884e3f04e608d76e0f0bae684e1fe799c5350adaea8a5c4515bbbcf3c086fc8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3787,7 +3787,7 @@
             "generatedTestHash" : "3a8be96d883144f036a6cdaf23ec134a3fc9adccc52e68952ec417657ed82656",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -3895,7 +3895,7 @@
             "generatedTestHash" : "a864a25550ba8a4f10f0065371b81430984620da6d0eafb05cf6ba9e3346db64",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4003,7 +4003,7 @@
             "generatedTestHash" : "41e7d45e51be9095645bb024082eebcdc7fc37b036e3898bb5e11fc8b774305b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4111,7 +4111,7 @@
             "generatedTestHash" : "8e43c6228968c665c9c2d8e2ee8824aa68564f84d5230f4a0d1cd2b7a7b7f252",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4219,7 +4219,7 @@
             "generatedTestHash" : "eba9b24f027207438235a1f860f4b56b3704d3da5a2a9eb32047f79454023439",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4327,7 +4327,7 @@
             "generatedTestHash" : "316b5b9f4e0a0efbd1033f1b1cfd68da0c1d0b2dbc3f2ac08092d2a192bcadd5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4435,7 +4435,7 @@
             "generatedTestHash" : "536bc1d4b007b3662fcb6f99811fbdee389d545f2660aa35ebe0c83cae16bc59",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4543,7 +4543,7 @@
             "generatedTestHash" : "8f106628cde8f760cc38d91fcda12ca25347ee960d3ff1da4acbb66b7a60eabf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4651,7 +4651,7 @@
             "generatedTestHash" : "b4f6c91dc721086b7003d774db3aa482d06fddcba71cd5d22cd17ecbe9df19a9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4759,7 +4759,7 @@
             "generatedTestHash" : "638bfcc18446332e1f224847d500282bfdb5ec7a7f74109bdfa487f3a6c6437c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4867,7 +4867,7 @@
             "generatedTestHash" : "5b0d1e1143973b97bc61309076e4159a103fb4de66475fcd82aee1498318a2c0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -4975,7 +4975,7 @@
             "generatedTestHash" : "905c9b783d3ca5fc5ee6f00189864ab36b84536863262b796177be05e8a92058",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5083,7 +5083,7 @@
             "generatedTestHash" : "ebae111efe3404b6a718ba60330520e97e6fe1157cac87fca53f456cd82bfc59",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5191,7 +5191,7 @@
             "generatedTestHash" : "7d61d0afb91e88d5a8805cbe804dfc1355444ab4bfc2ce21e883243a7a4d251e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5299,7 +5299,7 @@
             "generatedTestHash" : "63e473c855b6e47966fb3f514b3c135e6d9d6dc1cb934f429d90a156f19a24dd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5407,7 +5407,7 @@
             "generatedTestHash" : "4223539729e9770f538ee1026404b67872afd35f31917cd1274028d513d09043",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5515,7 +5515,7 @@
             "generatedTestHash" : "b29324a202a43e618e9fa188b08f2b77ecd3c02e570e212770e881ba8d584c70",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5623,7 +5623,7 @@
             "generatedTestHash" : "7daa0641f042fcd5942b324981b172d6c4883372c221826f0f77d0a85eabf7ba",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5731,7 +5731,7 @@
             "generatedTestHash" : "0b8c90f0108c88c1198d48563f7720347a8309736734713a23bf25099f371662",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5839,7 +5839,7 @@
             "generatedTestHash" : "f80c011b3b1b7cb4b97190d6f1fac136aef8e248f854bbe95657f1a43e1af931",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -5947,7 +5947,7 @@
             "generatedTestHash" : "6fdfb51ed010cf85882d55c47f3f4eda17c998dda4622d438de6851b5407d398",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6055,7 +6055,7 @@
             "generatedTestHash" : "a44fc9dfb1b34149fd1aab1cfd10b048763f0556e9dcddf8b753756945879da1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6163,7 +6163,7 @@
             "generatedTestHash" : "a676259cdd3b80b3eb7778a70efe7d2dcb877bb40e72d5577753adf85642698d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6271,7 +6271,7 @@
             "generatedTestHash" : "c8aa26d877117b04f3b4d2ec30f7380043542cc1a09371066fa8f4bb11d0c698",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6379,7 +6379,7 @@
             "generatedTestHash" : "e36ad346adbcf70606e4c03c09faa068ff7a7730776f91f8d6426c9322c89271",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6487,7 +6487,7 @@
             "generatedTestHash" : "14f7f2b5daced79767f45d2c1f17472ddff8a5efdd98687d1da77accbea836c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6595,7 +6595,7 @@
             "generatedTestHash" : "ef41c8f510b12b763fde1ba6ba09d0fe1a99d25da85b1083bdbc48e320b1eeb4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6703,7 +6703,7 @@
             "generatedTestHash" : "f0ecf7f90ea011a99d36292e9aed6d2ee13b969a6cd8b63fb97458643f847527",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6811,7 +6811,7 @@
             "generatedTestHash" : "1dd5996ee474aa374e07194d57c49f09562381cfebd6a1f499af179304d185f8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -6919,7 +6919,7 @@
             "generatedTestHash" : "ac9eae183b8a355692d525f8b0d10f5cb43108bd176361fcf5dd61032dfa7312",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7027,7 +7027,7 @@
             "generatedTestHash" : "db4310ac2a4871171fc67e07d747220c6fa10e35b529f7d9bcb86bdb02aa1006",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7135,7 +7135,7 @@
             "generatedTestHash" : "3d27c91ab3afe1a89bdbebaf7ea89097242c9005110216c50959398413780edf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7243,7 +7243,7 @@
             "generatedTestHash" : "27f90f5dc25942b2d441b343e759a1014da4d25341e9985d2cd0d899b850b4cd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7351,7 +7351,7 @@
             "generatedTestHash" : "b794c67bea8c687184c437f033a1d2bad2bd40eeea3e5e6a42f7fcb77d479432",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7459,7 +7459,7 @@
             "generatedTestHash" : "413e185de82c26d455b4fe1747d1829d7c58c3cfdef0c32c01aa3e1c8609e713",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7567,7 +7567,7 @@
             "generatedTestHash" : "c66e04ddd97315c1d4cf4ebc498e38883b9cb1bf8a2493472b2ef93ba91f293f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7675,7 +7675,7 @@
             "generatedTestHash" : "a924ae1fc2ebe3e1ac37a20bcba6b482be34ca22149045cdb7f7f38aa2e9854b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7783,7 +7783,7 @@
             "generatedTestHash" : "a13627335f4266a1689e3298553a49a6800fdf183b5f95f5fcb1ec48c3c12730",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7891,7 +7891,7 @@
             "generatedTestHash" : "112ce649ffaef06e3fc508857d36954977e67cc0f464384742291c69120b2646",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -7999,7 +7999,7 @@
             "generatedTestHash" : "bedb4ba7882f00bca50ef9ed53a778f1d2e7eed41dbeb683c434069e4937f5ef",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8107,7 +8107,7 @@
             "generatedTestHash" : "35184f1b3ff55285cced6de4ce774f53f4bd8340650eea7a283fe920c307e7f0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8215,7 +8215,7 @@
             "generatedTestHash" : "8336e913e4f044795c18f8287ec9b6b881b5868fa9f999a0a96e87be7f1baf18",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8323,7 +8323,7 @@
             "generatedTestHash" : "c8166015c316c38397a3244a67f7905a3ff4dfcfda4d4b215c16ca1b6967a8e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8431,7 +8431,7 @@
             "generatedTestHash" : "b23ce201b70c800cba07c7bbbbee7a7c641b01f35efc7b7425b4963351372d87",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8539,7 +8539,7 @@
             "generatedTestHash" : "f9f9193ce9d572475b7cf55b8e40db396de4cd57c545f4c79ca25e63e7e6a240",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8647,7 +8647,7 @@
             "generatedTestHash" : "577b5bc79f347cbe2caba1a67c1ff384aa829156ba255d4c3fc0cec8ebdd3781",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8755,7 +8755,7 @@
             "generatedTestHash" : "6cc8614f7a586ce376bbe4f6e230b3b771af1cd664a55a34a6cff746e30f1544",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8863,7 +8863,7 @@
             "generatedTestHash" : "29857ded04365cde0da697d344851d1cb8f84852f8d803883bd45a66b1f7e9fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -8971,7 +8971,7 @@
             "generatedTestHash" : "f904373e32f0c9cdbb4d07e1f113f65dc9c2d1ddb649d2e66ef29eb42a19ac61",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9079,7 +9079,7 @@
             "generatedTestHash" : "98a9662251717a5b5a637e6b49b44adca7b940d61f689c2ab4d4144d29160c4b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9187,7 +9187,7 @@
             "generatedTestHash" : "c202ae38cec6ca8c5aa010beafaf7177542cfdedc8062c7b907a04832e21c8e4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9295,7 +9295,7 @@
             "generatedTestHash" : "3801620a7fd2fe4254297dbd5dd21caf6183c96e42c92dea31ab94d59d1dc0c3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9403,7 +9403,7 @@
             "generatedTestHash" : "fd8927f3f5614450530ca2e9d770e4ba6c7ad3469e10d25c46a8379d123ef3b4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9511,7 +9511,7 @@
             "generatedTestHash" : "2abbae562433965b8ae1f9847780510d1953717b5f032e2d6115cfa1e35d39ce",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9619,7 +9619,7 @@
             "generatedTestHash" : "b6bd72c064d9022f6748812d1ac8d4efcc10a0f41aff6541b1ec4ddaafc46c1b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9727,7 +9727,7 @@
             "generatedTestHash" : "7b3127a6256fd059f32c7882bff90d9aa35d57971f85552e57e001b31a3dbc0c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9835,7 +9835,7 @@
             "generatedTestHash" : "c768237d30b5efdf2d6eb24f2519e786550e0a2b60b31ae6b5edba24bf6719c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -9943,7 +9943,7 @@
             "generatedTestHash" : "092ab2ac168892e87a7c75310b4b481031f614e21693f02b8aeab9b09484b7ae",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10051,7 +10051,7 @@
             "generatedTestHash" : "2b7b1984d6e25dd0987a9b7e8cdc7d4d246b07f029c1f657ddc955e5f2cd7d86",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10159,7 +10159,7 @@
             "generatedTestHash" : "706301fbfdf02ca850a35b84a7d410b96583044ceb80c63d2673da376cd14ead",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10267,7 +10267,7 @@
             "generatedTestHash" : "b97d864150c3d00557a170b7b86178569798aad70dba03a89c4bfd9037ba05c1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10375,7 +10375,7 @@
             "generatedTestHash" : "221ad10bec1f348575f377e2a40d0a1efa7c7fa21be61ad92189b0a053f06737",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10483,7 +10483,7 @@
             "generatedTestHash" : "6beff4e886f4cd05bb5a66060c6f3cdbed5ec95df6d2796fdde73233df9678ee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10591,7 +10591,7 @@
             "generatedTestHash" : "8373704f6690a7c65357f7d542a73fd95217f258080a7906c44bd743f2284bff",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10699,7 +10699,7 @@
             "generatedTestHash" : "7d570837a16132e2f5c27e1ec72667de65049038ad7f1879f1289211051852d6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10807,7 +10807,7 @@
             "generatedTestHash" : "1e1f5578fc20f096525ef594ac4103b8f1b6a6eaf997fcfffe08d1f692003bdc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -10915,7 +10915,7 @@
             "generatedTestHash" : "ac7d8e7b068c34196f3ace05a5c5d6359f9b721219d03200c7fbb8bab83a13fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11023,7 +11023,7 @@
             "generatedTestHash" : "e9fb75ffbeea04b30b0e5a9d79092731f090c5ccd00655dcbc2585a32fc0b31c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11131,7 +11131,7 @@
             "generatedTestHash" : "26c5c03f646d4ab84c5ca34459d6731d259154b22ed246a7072d201259e505d3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11239,7 +11239,7 @@
             "generatedTestHash" : "46da96e050c066dfcb5c393aec0a86af37990f012bd5a678a4654d854314fc6b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11347,7 +11347,7 @@
             "generatedTestHash" : "01398a076fd5db6846be68a766282aa13ceb087f405ac385abd8031e9be50b25",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11455,7 +11455,7 @@
             "generatedTestHash" : "8b36a5851e7b8dab2ec0ac011ddaab399cf038054cf718515136ca857744a370",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11563,7 +11563,7 @@
             "generatedTestHash" : "7f3f567f246ae4df73edf5e4a9ff8b0865090778cf23b88f35ffd7d5a9b8ed87",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11671,7 +11671,7 @@
             "generatedTestHash" : "c68680bc2f4e8aadf31bf579a83e235458b26500575e70e221b209d90a8c880f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11779,7 +11779,7 @@
             "generatedTestHash" : "c79bed1d2fc2ee778581173aa45c2d95775690decb638f5251185d4912752d43",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11887,7 +11887,7 @@
             "generatedTestHash" : "00493db24c641a854d3bf6f4f0a38733df7a23eed065d32718370d75a1764c7c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -11995,7 +11995,7 @@
             "generatedTestHash" : "2e4514b84b66ce626419e1c71fa4e5f9ddbe885964cfae1ad9abe3b2fbc74ea6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -12103,7 +12103,7 @@
             "generatedTestHash" : "9cbf7a3b7464780609ed8e883860d8fdeccbe71d17c4896c00a9db10085194a8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [
@@ -12211,7 +12211,7 @@
             "generatedTestHash" : "306c1919f57811e64b973edec8acc826707c7340ad1f1a1c67477e5ac48dbf7c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1Invalid_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1Invalid_FromEOFFiller.yml",
             "sourceHash" : "72106aeba7e45aed14d7b17ce2306fba0607393adc0f1530f7e2ae99eaa6e2fc"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1_FromEOF.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1_FromEOF.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "f8ec9ef52034c5f7ec3fce6119b33a57ed9fdf72a4f4362c3caca01f22f16813",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -115,7 +115,7 @@
             "generatedTestHash" : "382f99691e42785da1513cfaca3942f762ab51700aa4a8ebb1c6324f12fde56a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -231,7 +231,7 @@
             "generatedTestHash" : "6a756d91a3264a35e20d7ac85e59c6855f1cd900b0be3d870c7aecd72320606f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -347,7 +347,7 @@
             "generatedTestHash" : "2f5ddbb161906a5a215d73a0b00a4d6338430e0655e7e095376ba637db3c6d90",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -463,7 +463,7 @@
             "generatedTestHash" : "fcb2c55b53a1334b5237e5bc3c4dcafa07c6e71ffc615aa69e28dbfedf9e5ce5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -571,7 +571,7 @@
             "generatedTestHash" : "c3f5531f033117a880e97a37523cae1e9a36d31631d44a00a012faddf7c47a0d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -679,7 +679,7 @@
             "generatedTestHash" : "4ee7f349bbd16bd90a43671000cf3da528440a77c0fdd80fc13b41e44a9f8293",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -787,7 +787,7 @@
             "generatedTestHash" : "ff20d668bda04f51ae512f8440a15f76e7d8331a7040ab3033e09378fa1ce807",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -903,7 +903,7 @@
             "generatedTestHash" : "92e8aefb1c8bb89618b41358443525dbd6ad391b01ebeeb42824e012a6664adb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -1019,7 +1019,7 @@
             "generatedTestHash" : "245fccc71efc3c55545daff333a7b5a7cdc81661dcf8dccf2dfebc8827dbdcc3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -1135,7 +1135,7 @@
             "generatedTestHash" : "22b16b44d9da19fb0a6dd6127769508d3f05088ec9ea236f6804a8d4b4d1d193",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -1251,7 +1251,7 @@
             "generatedTestHash" : "7946d5e068f8ebaaa7bd024500e10267b8c3606acd522c6922f2e53d223cb5bb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [
@@ -1367,7 +1367,7 @@
             "generatedTestHash" : "8c58666ad177cb98adc1f114f998ea67a7a16a16e69b8ac01f3becb95d00bf50",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCreateTest/CREATE_EOF1_FromEOFFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CREATE_EOF1_FromEOFFiller.yml",
             "sourceHash" : "9d94d67c4e4d9349c116d617d97251b83238824a72fa5cca2423b7718f06f514"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionEOF1.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionEOF1.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "e82f12f7e7181e862c6745f485a6689b31aa1e99033febbc8e92e62d03cd9454",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -112,7 +112,7 @@
             "generatedTestHash" : "aad5aeed44f03e13fc22a06b2be52338a1a49cd3ca91a946a785e70e04cd8009",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -212,7 +212,7 @@
             "generatedTestHash" : "8ea84e61810d6ec90a357cdb45253a5c989ca7d4025757418e2788487335c0a2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -305,7 +305,7 @@
             "generatedTestHash" : "8ffc31618e0c0a9fca7ab6920dcc6aa2607b9a8c6ac9242917d2b37c75b01b2d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -398,7 +398,7 @@
             "generatedTestHash" : "a6dd3ae6b4ede59f9e01a4c9461843d01018bdd07b76968e5b7427b6730e4565",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -498,7 +498,7 @@
             "generatedTestHash" : "22f3f33c3f39e55bda278ed6d043807f7bbbf5fe22f21fabea2ebde03582bafa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -591,7 +591,7 @@
             "generatedTestHash" : "f6908db599465f583dd417990e21742bce2c3bd9b97aebdb358af0a76d2d60be",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -691,7 +691,7 @@
             "generatedTestHash" : "359ecab899a49ce66138f84360c168bbce06f6d636c8ede230dec577cfe718e0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -796,7 +796,7 @@
             "generatedTestHash" : "1c603f3c752824e4c8d07e714f28ecdd3d96c8521598817993a1be24648e023b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -896,7 +896,7 @@
             "generatedTestHash" : "acb877e61f663c2e2cf576e19afa1a9a461aade56651f03dcc52d95fa543b394",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -989,7 +989,7 @@
             "generatedTestHash" : "75c92f376d108e51bdd1ffffce839ec9b1fef2787c6ffc5284e70dbfbe035703",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1094,7 +1094,7 @@
             "generatedTestHash" : "aa16d3eabe63c3e4c52ef9532e80efcd6b7bc91734690365222cee4da6b5070f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1194,7 +1194,7 @@
             "generatedTestHash" : "8f819ad5cc184fd6a3a0c60b230fb9cc270e15155ad25037de6f78a05b3fdbb7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1287,7 +1287,7 @@
             "generatedTestHash" : "17294ed7820b2df0d8a17a3c0905e17665a40c73fef51066c811e619a3162c06",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1392,7 +1392,7 @@
             "generatedTestHash" : "a40de12221e21a9d5954e2068ccc0a80aacc9db7877b17d6e60c12b37735959c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1492,7 +1492,7 @@
             "generatedTestHash" : "8f0388cd643581b51386289e495b1930c1103a8309f7c3d547ab3d48a6d60037",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1585,7 +1585,7 @@
             "generatedTestHash" : "5cbcddfe0f035c11204e4109a257a9083ccbec5b6f83c9793208a96fa5ea0c22",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1678,7 +1678,7 @@
             "generatedTestHash" : "a84275c3b1496ad8229fb335839a658341013c4580893700e29c8be4ef3dcfaf",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1778,7 +1778,7 @@
             "generatedTestHash" : "30b1b7611518e123c1986c555db54017fe1eaebf502731da4bd181b58efa52d9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1871,7 +1871,7 @@
             "generatedTestHash" : "aa1cdc2b86d54703e7375bd8924aae90993e1d20537b4b3711af96cfba77d708",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -1971,7 +1971,7 @@
             "generatedTestHash" : "f7754a3a073a16a6ba4ac5c77210c53356f8c6e1570749dc320e6b8eee29a743",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2064,7 +2064,7 @@
             "generatedTestHash" : "663ec607805788a34153d6d9e9e2fc7d5555379a021ec641bc4a234b2e17fc88",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2164,7 +2164,7 @@
             "generatedTestHash" : "e59f3b886bf844606520a2c795ae21921423b9f955e85f48c53c5a677045f06e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2257,7 +2257,7 @@
             "generatedTestHash" : "b3d6133cc5df449d648e5549c7ddebf31b8f5effae30615aa55bb12a103b16e9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2357,7 +2357,7 @@
             "generatedTestHash" : "a10c56da1ede097e231935652dff8c99b324b8393287d04272ebe891734f899d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2450,7 +2450,7 @@
             "generatedTestHash" : "ab851a8a02eeed4e4a0f8848b378afc3ab5364b8e240a41c157f41b920b19136",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2550,7 +2550,7 @@
             "generatedTestHash" : "a8c46de9c8093f82687ff6ff80106c12d38294c6f048b4bbf776689afc9c7fbd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [
@@ -2643,7 +2643,7 @@
             "generatedTestHash" : "828da103008b05102fcbb3c6c7dee10b36c486c83a98ac389df8cbfe4d3b037b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionEOF1Filler.yml",
             "sourceHash" : "26471de3ab28cc3956315f3b5571289e33c0fea1f76aa2636e7ad69a93d66061"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionInvalidEOF1.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionInvalidEOF1.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "a013c0f7a408b824fbcb07ac99fec3d7fd8a81b58ff1b1049addf2997807b1f2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -100,7 +100,7 @@
             "generatedTestHash" : "66a0424a20d7a6fb347a6aa4685a7470844bb8d640744a8bb4335e07b770cffd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -193,7 +193,7 @@
             "generatedTestHash" : "03b050bc951796306ac3ed29a26320240fcb91ce44abe9db02e2175a33445d33",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -286,7 +286,7 @@
             "generatedTestHash" : "f4ebd054f0fd6a0115afab3b1afabdef2089fe5dbdd8f5dd021a5280e8a6d3d5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -379,7 +379,7 @@
             "generatedTestHash" : "ef0a25a28baad5237c970e8bbb2db96f3210af879265bb6d0242d6e669b7c4e1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -472,7 +472,7 @@
             "generatedTestHash" : "2ab8893b596091ecb0c62f9881ac86daa96e60128d6132cc15b4f65f2d70a8ad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -565,7 +565,7 @@
             "generatedTestHash" : "167cd6ace77775787c7561d286274b8c0644e782d74500df5cfc262a0633c1a0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -658,7 +658,7 @@
             "generatedTestHash" : "c7bf13fe81aef697fd32e7af012150a4afe1742a2e3a9e9ab5af310278f71193",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -751,7 +751,7 @@
             "generatedTestHash" : "baaca9f32d9d16cfb02e6bf14be7d26d5a3fa180a8658d05cc1dfc46eb7c1a75",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -844,7 +844,7 @@
             "generatedTestHash" : "cab1df4067e64d0ee742e8b5bfeab987d275e40f278162b99bd862652ed8e7a8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -937,7 +937,7 @@
             "generatedTestHash" : "16debafee6e02263909a1643023bee5d685335564377dc938f7e5fa07cc0f6b2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1030,7 +1030,7 @@
             "generatedTestHash" : "390f0e5a2f9a3e5c669dcb2180551a3812a9bb877341dfcfb9b3b0d8e61114ee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1123,7 +1123,7 @@
             "generatedTestHash" : "b236dc68ce09a76a493dc794a3225503eb17312d95a643d61436dd848258801f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1216,7 +1216,7 @@
             "generatedTestHash" : "0837a9ce941a9802d9d1c7d5119f1e682f37393090c3b5389f74fcc2835209f9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1309,7 +1309,7 @@
             "generatedTestHash" : "7f19503416bbb91602fc95a37c526e772c526d438872b7a081573dd5fca22e82",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1402,7 +1402,7 @@
             "generatedTestHash" : "53fb5eca047d32a15b6e53ed965469b0c29ae6ed44cab8cdf9e8549d2092c54c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1495,7 +1495,7 @@
             "generatedTestHash" : "9207b39e25f9487a1b92a46663a85872e8a8d82b840b98774892a49d40bb36a3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1588,7 +1588,7 @@
             "generatedTestHash" : "d09f0208fe99de2b42d2f6a06cc7c1fd0279d7597c76673e4ea83e867e0b69fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1681,7 +1681,7 @@
             "generatedTestHash" : "2b84e56bafd4cce3e3da85efb588dc544a5de8bb4ed1262b78aa53d479cfa90d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1774,7 +1774,7 @@
             "generatedTestHash" : "06166f830fa0417d6530c7987ac04ce1a5c371b1676e2dcaa43fbea967b63ee1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1867,7 +1867,7 @@
             "generatedTestHash" : "84bcb2beb2913ec752bf5b4af2b3599c9996390015d01b976b6f1732e42c5d90",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -1960,7 +1960,7 @@
             "generatedTestHash" : "8b746eab29db4b42b9c804c26cb9c0ba1205380e464cfab5b2380f354bf38cc4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2053,7 +2053,7 @@
             "generatedTestHash" : "6e58a6aea141ee47aab0ab45e0a5b730af5295a75ee950302b83b3ff383935b9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2146,7 +2146,7 @@
             "generatedTestHash" : "cb2d5d6c799d1d68273cbdc3ca56775f6054652a2cf96f2b8c4a806c4e86e41a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2239,7 +2239,7 @@
             "generatedTestHash" : "44887fd3309d6ff2bcdb8e0ef5a73162e159433942c559d3934b69bba8e9cf56",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2332,7 +2332,7 @@
             "generatedTestHash" : "50c6bdbbd216c5d5a7694e5c6f443892bb6c98fe9a9c6e582d27dac3d58b58a5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2425,7 +2425,7 @@
             "generatedTestHash" : "9246cb43974b5c8293f400a8c283ef301340a8671cf9cc2cb0940eaba8220635",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2518,7 +2518,7 @@
             "generatedTestHash" : "b57c8fb53de8e4f26d6624170d5dbef33589b66d3c622b90c2ae07bfeb2bdbeb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2611,7 +2611,7 @@
             "generatedTestHash" : "a7649a8314c8d37c4cecc8f419cd09119d109c7a4c7364928dccaba356012582",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2704,7 +2704,7 @@
             "generatedTestHash" : "7c3730971b481314338d45d4cf6fb6d840d89119e815d86c03017f1e15aee9c9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2797,7 +2797,7 @@
             "generatedTestHash" : "9c426876e6355553054e4bef8a4c514771b741ca4f1faff55d669565adfb3276",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2890,7 +2890,7 @@
             "generatedTestHash" : "5313b5c3ec9426b2d91a142d2f24d29a5a81dfdfc1b9cf906953048f8bd973a2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -2983,7 +2983,7 @@
             "generatedTestHash" : "e64bc5b31055f463eeefdfc0a86951f9d84c3d04db05f8342c83c49cebd0c249",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3076,7 +3076,7 @@
             "generatedTestHash" : "ed18fb564f24ff4c67f4fb1bfe7fbb149aee10dc74ab941c1f2eed044caf24f0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3169,7 +3169,7 @@
             "generatedTestHash" : "78de5fecc4d07f21de05d597921a211b82d0b25ffcbddd2f7641e9cf5c88c254",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3262,7 +3262,7 @@
             "generatedTestHash" : "7d944219a589c293876aec5ead38a1dc3ea9fc6d139b294348e80d208a67f627",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3355,7 +3355,7 @@
             "generatedTestHash" : "7b4b3b0713146554deaf65206bea2d44723ae6c8bbd126dee34932d25e95a1e9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3448,7 +3448,7 @@
             "generatedTestHash" : "6cccfe7b6a823f3f1b588eecf5230cf0b21a7dddfcd7309b7602ebba851adf62",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3541,7 +3541,7 @@
             "generatedTestHash" : "b3709854239eb5fc95c74431ad4af47aea31216d293888bc2dd4488fa4e1ec1b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3634,7 +3634,7 @@
             "generatedTestHash" : "06846097eddf8055f468dbce96b8370228a40683a097f4bf68bd5c421e92db1d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3727,7 +3727,7 @@
             "generatedTestHash" : "b2a5354ff1ebc01fd86a919f45ccdffc7921a0f96630aa197d986c5f14dc112a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3820,7 +3820,7 @@
             "generatedTestHash" : "b11f2cbc689af259f431962f08457c5e5c939a9b08565c106b5e3fb03098a1c9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -3913,7 +3913,7 @@
             "generatedTestHash" : "cc592beb84b9dd14944ef3bb8303d187958bcb144160bd3b99efd4f55e081516",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4006,7 +4006,7 @@
             "generatedTestHash" : "00ad22fa3089827e43218abae3ac77d1c718cf0a68a6a1b84b38f5f40081f039",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4099,7 +4099,7 @@
             "generatedTestHash" : "6c4c00c6a40899ecdcd1421783666f28522468953cf03d8e11a23bdd8f86d111",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4192,7 +4192,7 @@
             "generatedTestHash" : "1406ff88510c727719aa22fabf2bfedcad789ee32d75788122eb6be19b1059d7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4285,7 +4285,7 @@
             "generatedTestHash" : "003b4cb1ab9f27a0209174bc4b741be413f17a6eaa949b1e39efb6fdb7bd9911",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4378,7 +4378,7 @@
             "generatedTestHash" : "3ce9c183a751e93faf97c2ed5e5e4b2edeeec80e6fd124304e4cf0d2a9928065",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4471,7 +4471,7 @@
             "generatedTestHash" : "8efc8cfcde0b1ac3143a8057a07aa1188d11ea78faf5bbb21a9c18fe6e4d99ac",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4564,7 +4564,7 @@
             "generatedTestHash" : "3c7915622764a913faeecbcbc5f258cdbd10c5c206f250e2007fdaa6708dd859",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4657,7 +4657,7 @@
             "generatedTestHash" : "ae9ace251e95cf8a1c17e96395d25d20d16a3718d3c1f48a66afeed614431f9b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4750,7 +4750,7 @@
             "generatedTestHash" : "7e2f8756f66bc0af905ab9d87a933c9b0fafc3ae6a98f5523119a694da1ea3a5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4843,7 +4843,7 @@
             "generatedTestHash" : "b50cbed1cba48820cf9fd5523fe65bed91595d6ed0841b5264c073dd5fd57335",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -4936,7 +4936,7 @@
             "generatedTestHash" : "e441f0b9d17efd19a458d84cb2bb3882ecc748dfd29c08f680b8fd1fe56c8da7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5029,7 +5029,7 @@
             "generatedTestHash" : "ccc40a46d09889b941aa5f0e3dfe9d4f6cee955b1f58b383baa3d0366a2a848e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5122,7 +5122,7 @@
             "generatedTestHash" : "dac5c7fe10f0236ca85446fb475b41207e06a55a665e2f74c0197f78e838a966",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5215,7 +5215,7 @@
             "generatedTestHash" : "335268a5c76e96f9d9158f88c9c3042d9386697ec10fb522dd3b109e720e7cee",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5308,7 +5308,7 @@
             "generatedTestHash" : "7c1341ef791c82c3d384ca110b218fbb7592062770235ed121cee7995e8767f9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5401,7 +5401,7 @@
             "generatedTestHash" : "327fb49d6aea6c8f6603f8aa99ff6514f32961a74d98fa2c6ae383b302a35c17",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5494,7 +5494,7 @@
             "generatedTestHash" : "454b6979aa3bf1ada6fb939d3305b9a48dcee411dde47f4c96a1e104eaca942d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5587,7 +5587,7 @@
             "generatedTestHash" : "5d6c5fe0b88f8491f1700a8b76e8cce7f2b2a467298a3bfcf78b121d00f24b36",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5680,7 +5680,7 @@
             "generatedTestHash" : "d01bbb358f4e440543557725b585a74869108d0d43669aa864d67cbff74d1149",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5773,7 +5773,7 @@
             "generatedTestHash" : "bcd007d3f7f92dc1d1ed31f6a39aa6f98d501f8ecb8619e4a215eeab25f6f84d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5866,7 +5866,7 @@
             "generatedTestHash" : "1d244fac5d1b7bf193d3dae724ee39421a17ec95e14ae37d1338f89d87ebcb68",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -5959,7 +5959,7 @@
             "generatedTestHash" : "932463d21696db919d41200858d53d932e878693f13c1283110ecb4585651d42",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6052,7 +6052,7 @@
             "generatedTestHash" : "e603ed9c1b03f0d28e2a52358166eb28a51d5e828039efe4d9924e3ab5f44d90",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6145,7 +6145,7 @@
             "generatedTestHash" : "f66533e98ea8c51635039b3354262f1eca286c1e207b97792bfbf041e1785a42",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6238,7 +6238,7 @@
             "generatedTestHash" : "fae782c6f5ff6dbb776360ddf39d7356a7d4dad4e1bd9f24ddbcc1e072a5dfa3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6331,7 +6331,7 @@
             "generatedTestHash" : "d31bc25c70e7069bf88b3b1e8aa0ff6f13849b368b89822582977ccb36ca1b43",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6424,7 +6424,7 @@
             "generatedTestHash" : "ac5f1a8d7a11a29485b800be6440c20f38b2ff1cb17e3fa48d03bd9e012fc511",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6517,7 +6517,7 @@
             "generatedTestHash" : "8a4e96b3b4f9b9525a1c2b086ea8a2e7c225c842fad5e6204ec9a859e91ad92d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6610,7 +6610,7 @@
             "generatedTestHash" : "cdf1487bd1db8ed0863171f2fe2a43767ced525c266c1c650bfe005231ed2180",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6703,7 +6703,7 @@
             "generatedTestHash" : "3e1b79be1bf3221973b8bc101e6c8c92fd295b93617f17d1906793458165cc1e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6796,7 +6796,7 @@
             "generatedTestHash" : "7d3aad07f260b2b9e8d19fbb04b3c6d1850547b957cc3ac9836d698551fc21a2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6889,7 +6889,7 @@
             "generatedTestHash" : "c039f6fbd719846558f4bfb9b92bdfaee55355df9d3ee951940237693179fbb2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -6982,7 +6982,7 @@
             "generatedTestHash" : "ef348b602c2c216e09912ad50f1efadef5cb3b2ff04e394fcc7f475a6812131c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7075,7 +7075,7 @@
             "generatedTestHash" : "1613cc8bfeae31e06f8dd90bbc0eb78a42c24e62d664a26af89d54099b64759b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7168,7 +7168,7 @@
             "generatedTestHash" : "73abe07d0561ba2f50437a8ebf4201870531f2f42a4bff52a9518a7bdb35ce76",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7261,7 +7261,7 @@
             "generatedTestHash" : "084acadf44abfd60aff8182fb63c1b62a3ba9e3378823c77789bbb95f296d69d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7354,7 +7354,7 @@
             "generatedTestHash" : "91591be72a2cd2d8052cfd056e3f76f1b4716a205d73084d43bf0507f9a4c02e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7447,7 +7447,7 @@
             "generatedTestHash" : "0e1a78f574b090b7e9c2d96d992260ecf68ea41ca1bba4204257c1ca7d123ed6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7540,7 +7540,7 @@
             "generatedTestHash" : "679ec63cc259a5feaffec3466de67a18faebc440f504ddd2849ab6a667c67288",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7633,7 +7633,7 @@
             "generatedTestHash" : "d1337599ea5ca03ad05b1e4c154f6eb032326e9816df2152209cc7d893722767",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7726,7 +7726,7 @@
             "generatedTestHash" : "36f53438ec5e28d451dc648a4eb3e947378548ea302f0c3d3fa137569c461cb6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7819,7 +7819,7 @@
             "generatedTestHash" : "50f334160e3322c54ce0875d7c90b257449649e1be781b193847a57d1e57bc85",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -7912,7 +7912,7 @@
             "generatedTestHash" : "d9889c1f60fd986b3fcac36230b35e75c5e46f852681b9d2104b02bfc114d086",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8005,7 +8005,7 @@
             "generatedTestHash" : "1f6dba84d667e243a1e40f34ab3ccb1d090331351886424822e3b8df451ade27",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8098,7 +8098,7 @@
             "generatedTestHash" : "509cb6f3a3c198433563c5cec0c035d82e37c82751f2a08a86f6ea830405de30",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8191,7 +8191,7 @@
             "generatedTestHash" : "4a2f8047bf394d38930a8c82c6eb23bcf05261e1cdc85068abea538b99b807d8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8284,7 +8284,7 @@
             "generatedTestHash" : "d591e25c2ee4b30a72f9b1c7fc6d0d60b9ed7c22f3af64aafeddc1fe8ca2dcc2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8377,7 +8377,7 @@
             "generatedTestHash" : "8051b5a8603312e9468c6eac571e856efe604f688befa719f65d26c4efff7f14",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8470,7 +8470,7 @@
             "generatedTestHash" : "e617b31258eb454115c30f1bb88492f8ae8afcd46e18ce461b0721a6a845166a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8563,7 +8563,7 @@
             "generatedTestHash" : "c5c73dce3ff35771c813eb521012ea24a9803f2bed475cd8122f17aee21d3f91",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8656,7 +8656,7 @@
             "generatedTestHash" : "8c3189993fc22f2ca595cac0ad8f87caad89fcb3724a2ec28bed3afe8dcca7a4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8749,7 +8749,7 @@
             "generatedTestHash" : "f469b6e5936495638f0be296b853c4add4d99379eee1e119b750d4abda5497e3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8842,7 +8842,7 @@
             "generatedTestHash" : "25ab2f074fef3fcee20daa821a2719ab9ca745e0230327db031e43f3fd429e49",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -8935,7 +8935,7 @@
             "generatedTestHash" : "e988841bed88804c6d93b3b7e9e46ac1377516229db09dd9e372840e4153f946",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9028,7 +9028,7 @@
             "generatedTestHash" : "09e46b66d8b94e94947b6353b990f063a5abec28ca14bd71c1e13806f5ee261a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9121,7 +9121,7 @@
             "generatedTestHash" : "9a21dd6d01fc44485bbb4270bacd0edea850b1d7f67871348f8295e59bd64061",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9214,7 +9214,7 @@
             "generatedTestHash" : "11c6dc99a07c09affa9f5b3ec2bc62c86e76fad3ef0a680be1a7b15bd55ed3c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9307,7 +9307,7 @@
             "generatedTestHash" : "bd5b1bbf7f15d312fbf6453d494135876898acdb1cd39f8d143f8ec79de94c13",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9400,7 +9400,7 @@
             "generatedTestHash" : "96004f643f1af845b9af702b292debb175c8bd6be75234068ce335861a6bad65",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9493,7 +9493,7 @@
             "generatedTestHash" : "c31c8cda70224f6212d0a3ca686347047d6e1821640d04ac9bd7d5558d81a86d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9586,7 +9586,7 @@
             "generatedTestHash" : "c1d0c20a6404477ced5a51b1ad6563dcf5bce41709651967708c04bd2deec357",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9679,7 +9679,7 @@
             "generatedTestHash" : "dd2b6f4ecce0c24000bfff7f4a4415145d2f7683eddc622860e48dcec95ad46c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9772,7 +9772,7 @@
             "generatedTestHash" : "7a6c8e33b03ee9715526e88f456fa639433454b46dd2fd8773696604613c8fe7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9865,7 +9865,7 @@
             "generatedTestHash" : "7af6538eb2af78724877b6dc3a48c3fd179ad6c8982ac1802c836a31fac4f6bd",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -9958,7 +9958,7 @@
             "generatedTestHash" : "7d34998bf37c1d9f6e42ea85113c8920eb04185607569dab10aa956e1fcbc7ad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10051,7 +10051,7 @@
             "generatedTestHash" : "14c81ba03951ff1a1b1d8d591273e1abd568b3d4457ce6e55fd3948a48636f72",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10144,7 +10144,7 @@
             "generatedTestHash" : "73a4837de85c9fd35c746bace6b8829528756ee6b360d05839ff45a4ad2738f6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10237,7 +10237,7 @@
             "generatedTestHash" : "3083834b604b15422d3647792e22383bc84994841cd6859a82520b44d5766376",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10330,7 +10330,7 @@
             "generatedTestHash" : "d3d97e2750870ae76373c279623faf44ab83a269304208693e7e613b0e8c4272",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10423,7 +10423,7 @@
             "generatedTestHash" : "42eed31d73e5259de20173a0ccaceaa099e74e9b8cd0d29ca9e5918ce238f28c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10516,7 +10516,7 @@
             "generatedTestHash" : "3c061b2bbabbb61904dfafca83c7402d6a3d428e1a23c3a4c60506fabc50dbc5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10609,7 +10609,7 @@
             "generatedTestHash" : "15a49784e14d34b9c04ab649e0f64873b85081f321ea8fc5c2a595918a4a38ad",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10702,7 +10702,7 @@
             "generatedTestHash" : "7f1fc8729368c6a67fee9d28f3954de3f33497fd2e3428c8ab372695387c102c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10795,7 +10795,7 @@
             "generatedTestHash" : "e7ca7f662b029a2708c0812b494b2bb696a78016a63ea6f7715da6a2e7e65248",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10888,7 +10888,7 @@
             "generatedTestHash" : "10b7a0b1e3a3a8d76fc98b99df95d51c0d12b7f931296f6fddce167e0e729133",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -10981,7 +10981,7 @@
             "generatedTestHash" : "f1015c73a309749514322a669e016a3b93f84fe205e25bee39ade752930092dc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11074,7 +11074,7 @@
             "generatedTestHash" : "198ffa62f34c93868388dc2a96fd7e77b08e5dd87f0e52eea3478a5e304781d5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11167,7 +11167,7 @@
             "generatedTestHash" : "f0be4fb3215e7a0193919b5dbcbc850ac43ef07d1ad1987dba961de848f5c212",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11260,7 +11260,7 @@
             "generatedTestHash" : "21787df64354beaac28779be7dac9225e716b5f8ad992daea676b79d0c39b40c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11353,7 +11353,7 @@
             "generatedTestHash" : "606bc3c999ffe1e8725638ac09641113442f5652dd7ae01e92229893842258c2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11446,7 +11446,7 @@
             "generatedTestHash" : "822787ac136362a279e18fe950a0727963e4b9f84c319ac6a74d0e1599371ebe",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11539,7 +11539,7 @@
             "generatedTestHash" : "c9056dee032a1a0cc01c024312e563cd6576fc89537b4e9ed3eecb387ee84ae6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11632,7 +11632,7 @@
             "generatedTestHash" : "1ee697d81de9b35e8f4720bfa278efffaf4734846a0b2b551de50b39dcc107d9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11725,7 +11725,7 @@
             "generatedTestHash" : "6a3fdd624953fa51d1226830c969b75a2a2203990822e82308b598fb4826aa8a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11818,7 +11818,7 @@
             "generatedTestHash" : "c8bb35d4305d3d5b8e3d7138db237456862c521726432db985b67c36d943201e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -11911,7 +11911,7 @@
             "generatedTestHash" : "f536fec3468dafa183716b3c75bf83b7459c784d24b8910cbd5d951e16e5921f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12004,7 +12004,7 @@
             "generatedTestHash" : "b877be8ced99fef4079eb67106505908b3e5e670bf85ee0170f8257355c7c388",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12097,7 +12097,7 @@
             "generatedTestHash" : "797a466b876087b3a60c4ffb45b9222583eff5c8a5a9658618dc61706af4a9da",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12190,7 +12190,7 @@
             "generatedTestHash" : "9c7ea06b30b4c0c08fbea1b1ec413edb1a63169f6769f6e0973271013de0795a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12283,7 +12283,7 @@
             "generatedTestHash" : "1a692d279ff070a0ce932ff7a16059035de5cb2a564a576a86ce65e664739cd5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12376,7 +12376,7 @@
             "generatedTestHash" : "bb9135545c271f0fdba2694cb6d49d93d743a7e658b6f5d319de90cffea90e30",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12469,7 +12469,7 @@
             "generatedTestHash" : "a04bc3ee2ce043477a36eb9c19906077ce34b2ee4fbcd4a5ac5cbbd937a5f961",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12562,7 +12562,7 @@
             "generatedTestHash" : "fe36ca076e953bd28b246d65df477b78cc74efe3cf2c2ccec112274b5ed272fa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12655,7 +12655,7 @@
             "generatedTestHash" : "73eac6cd726ddea043cd3f755f9c3b819dc07ff5b3a2ad7bfe21186c12fb9312",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12748,7 +12748,7 @@
             "generatedTestHash" : "bdc188cd2dc0843d6716d3af8d1a293d6ab82b08e86e1c20a0006ae124ee6ec8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12841,7 +12841,7 @@
             "generatedTestHash" : "46279174da1010eaa6816f043c0f7c28da3d4f5bcbabcf50e89b877fb455cdf4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -12934,7 +12934,7 @@
             "generatedTestHash" : "e6c537f707e73055f984a104d8ffafb8e29068bb27aafc7758af12c402edad8a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13027,7 +13027,7 @@
             "generatedTestHash" : "b06e0cb1015a33f2f7cefa57b9c5a6023a2fb870ffe027f42d4a80f2ea038668",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13120,7 +13120,7 @@
             "generatedTestHash" : "685647191395873c2b23773ad709d6990802c1ea22a164cac5ec49f1e03f7946",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13213,7 +13213,7 @@
             "generatedTestHash" : "c2332e9947f5be2904e6da0cb9995889b559f359b99299a90b57f05d5d6cae59",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13306,7 +13306,7 @@
             "generatedTestHash" : "098c71a97c7626c5ef55dbc2ed5915d5feadc7ac562433a4578b440d0bb4f150",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13399,7 +13399,7 @@
             "generatedTestHash" : "d374a7f4db3429dbc11a85c05c0b47fe5af93b24685f7d69c366d3e19fbb2ea6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13492,7 +13492,7 @@
             "generatedTestHash" : "bd2883336e08b9b81eb63a5a8654f48b5dbc2d867f22ec97f99cc47726f404b4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13585,7 +13585,7 @@
             "generatedTestHash" : "27d1b0ddc6d57ccca3b5860e10607e49896a94bfa7bb1dcd93296d08e357b404",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13678,7 +13678,7 @@
             "generatedTestHash" : "f0a0e0c998c103d45a81c542687e9a5ed7cf374d5ff086dab4541728a48cb5e6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13771,7 +13771,7 @@
             "generatedTestHash" : "40c9aace19fb61d5ca47154b1a1b380ebebe24f75c554b99b2dbb5c68a651038",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13864,7 +13864,7 @@
             "generatedTestHash" : "3cfa9d415456547c2c6acd0a0a696ecb236e08a33363da8edfe6f7dffae081f5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -13957,7 +13957,7 @@
             "generatedTestHash" : "d9e8878ab4b713ebffa6cfec22eceab1c4084a0fd602e47a691e1ec2b47546eb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14050,7 +14050,7 @@
             "generatedTestHash" : "6d1217f8e559c8dc2fbb5367c4903e9aa645c9ef00c4812ee1bc5106e63feec6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14143,7 +14143,7 @@
             "generatedTestHash" : "3e74ba3d68db15bd02f2bc2b6d86c6f8dbb70ca6d99fcee827d291cfe2608c0f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14236,7 +14236,7 @@
             "generatedTestHash" : "d2a5cacc2b60b83b4f1e91a45c800f2e329ffd3349bdf003c0a9df168cd1eeb1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14329,7 +14329,7 @@
             "generatedTestHash" : "8c43361dbd6f417dc7c5cec0e33e141f04186aa9efd390ef4058fe0d899719e2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14422,7 +14422,7 @@
             "generatedTestHash" : "118fc9981228aebf23b323bf567a547cf3b0662256971293fa57b2376810ae4a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14515,7 +14515,7 @@
             "generatedTestHash" : "6d67b062d9866944896ebc527b1cae8d9111a4cb78362433e889ec328919baab",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14608,7 +14608,7 @@
             "generatedTestHash" : "61017642b51c5f2fcb351faf5d577bdc75cbe1bc975dfaa285228e17bbdf4497",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14701,7 +14701,7 @@
             "generatedTestHash" : "81313699724f7f9a1cde1acd5b50b823cefaae79f6b49eaa223832b01c99c10a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14794,7 +14794,7 @@
             "generatedTestHash" : "ecdb28b2fff5625f9e53d7aab2cbb2fa67f55f826648e4760620fe4c8d61e720",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14887,7 +14887,7 @@
             "generatedTestHash" : "edea3bd8a32d92503bde87fd694e55de6c15e053abf924a728ed2f23aef17b55",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -14980,7 +14980,7 @@
             "generatedTestHash" : "159ad8e7d61aca977ae184f2c59562a2eaa42c93fe5e37e1fc94d08ec4e023dc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15073,7 +15073,7 @@
             "generatedTestHash" : "c7f024431059f77fdd7ddd22694660357795a67cf39c8196c88a73a953a08c97",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15166,7 +15166,7 @@
             "generatedTestHash" : "1c23915eda8a86c261aa413ae7f6deaa77c7e1e9c1299706277b23f7841c1a81",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15259,7 +15259,7 @@
             "generatedTestHash" : "a883f27bf6653b4f58748517b4b102953c09538e95bc1a30db9d3dfc6f66b56d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15352,7 +15352,7 @@
             "generatedTestHash" : "339255681d81a67eab5004d5dbe4db8f1943188b4ea7900884d6ea18d6b86fed",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15445,7 +15445,7 @@
             "generatedTestHash" : "ce9ffeb8c2d01de70e5bee4d3b1cfd79e36e33765c1e472c45b829e0d0152534",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15538,7 +15538,7 @@
             "generatedTestHash" : "248763b57a5e5c852c23ce6357292805f9f87aba52286112a8ead5c0e3b383c9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15631,7 +15631,7 @@
             "generatedTestHash" : "6d37b033d0623aced2a2ef7a6cfbb0e9ba94756a2071d697b75be6670917871e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15724,7 +15724,7 @@
             "generatedTestHash" : "f502bd0db595f678b54bc7242b34a8815c640a20010f88a5f28e5122b1ffd73e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15817,7 +15817,7 @@
             "generatedTestHash" : "e9fd93fe7c693c44ed4160cbdc0c8c25fa42caee8afdd8c67d9056393d80524a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -15910,7 +15910,7 @@
             "generatedTestHash" : "3e63b1b329831ee7caacd4dc9279a0a46933309b1a41638f9851201cd284a618",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16003,7 +16003,7 @@
             "generatedTestHash" : "a5ee654739bac484afbbacc67d20095f61c2b9a10dc4016e2ac96a889d25ee4b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16096,7 +16096,7 @@
             "generatedTestHash" : "560b89d1cdb57f1c00bb839e7472ea03f147d655e76ed52995595cfa04826ec3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16189,7 +16189,7 @@
             "generatedTestHash" : "b43e254193d4a7bbc5b96c0e51a4169fd1249b5f025ad37a0320bf70d85808d9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16282,7 +16282,7 @@
             "generatedTestHash" : "2cbac1cc73c2da0559ff7522b02a35a458d185318e0ef3ac6cf74aba2b9c5e0a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16375,7 +16375,7 @@
             "generatedTestHash" : "ecbc19c7cff185c33d15e12e596d18c70deb2d60335a5041a5265c3fe430e55c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16468,7 +16468,7 @@
             "generatedTestHash" : "40c7229dee8bc9387ea81d55836cb5e3970fa32faf287aa276a286c4bca1a74b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16561,7 +16561,7 @@
             "generatedTestHash" : "a628b85c531a93e447eb209f52ac623919b782c2968bc3714900d367691118b4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16654,7 +16654,7 @@
             "generatedTestHash" : "d3c7a9549b89a3d3df026bad1b0e79d0bdefd1401cf63cbf38e6c6495689abe3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16747,7 +16747,7 @@
             "generatedTestHash" : "3e540302dc717b974afd37b06089012dee45f1b95f3d7f671b0746d7d9bfb06c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16840,7 +16840,7 @@
             "generatedTestHash" : "befae4cdb432c5021e284d5dd61d53ed301bfe542497ffb94d3ed93fd21f40a6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -16933,7 +16933,7 @@
             "generatedTestHash" : "b0a9ef50f9f098c43feea1f1a42aa9cff97990a3c69c18b52632e2d6c7a1c367",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17026,7 +17026,7 @@
             "generatedTestHash" : "a4b2fa01ce9489b6dbda8f9315be7ea4f03e638c8359f5eef5bf3db74b7db769",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17119,7 +17119,7 @@
             "generatedTestHash" : "eb53fd48030d8d8865d34aba8bae5797ca0401a54cdcc3427400fed4745f79c3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17212,7 +17212,7 @@
             "generatedTestHash" : "bdba266282e292713856187ac589367a8e0fabbc34505efbbb16b48ac8ef717c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17305,7 +17305,7 @@
             "generatedTestHash" : "4f2d051a9fa5de8c537f422ea345f4d9c9858efb18c8621b2db27ed18ad9ebfc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17398,7 +17398,7 @@
             "generatedTestHash" : "5742f5889c7fb39c94d9e7600ddc199beccd4c8abeb66eb02219c31143f677bc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17491,7 +17491,7 @@
             "generatedTestHash" : "01ef515cf0d2d75f89acc0cb90ecbb21b73e1a4e23294a7236ee796f9011626b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17584,7 +17584,7 @@
             "generatedTestHash" : "db3618a75319898b77e25fac92c5ca7ee6c2088b66a4463a76a1bf39bd74299e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17677,7 +17677,7 @@
             "generatedTestHash" : "4ef17166a8beb855d38c18917125a6235d42a86c994412783a245acaa3a7b2aa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17770,7 +17770,7 @@
             "generatedTestHash" : "270d0325171c98d1718f1543597677683a0fa679e173e57f0f6b011175e2c868",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17863,7 +17863,7 @@
             "generatedTestHash" : "850ca736344093c2a8ceb6bfc496e62c2c9702a4b522327bf22f7e9f58989533",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -17956,7 +17956,7 @@
             "generatedTestHash" : "4f953e841eccb52c5727a330f8dc396a8b2b3646e9852c8ad9cf8c084e6d3435",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18049,7 +18049,7 @@
             "generatedTestHash" : "6bdbd446165e7467675c8be8c5c12754d85209754dde654882e68f2516729160",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18142,7 +18142,7 @@
             "generatedTestHash" : "b573671824661d64c4074b64c0c8e054c374b83875cefb1b551232471fc4c84b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18235,7 +18235,7 @@
             "generatedTestHash" : "6a4ca8540dcf996235004e2a6d588d5f1f97f706ae4f4722d04ad211d2410447",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18328,7 +18328,7 @@
             "generatedTestHash" : "4ae88157ce9fac54fe4762fc034dd10a3cb4e5bbf62d0f67b737e4408de23f5c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18421,7 +18421,7 @@
             "generatedTestHash" : "613a30697ffc1f6a1e51e3b3217534b232caf38e806870569be502fc8de21822",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18514,7 +18514,7 @@
             "generatedTestHash" : "153d89f685025fe3d5950c793ff5cc074f55892543252fb610bdb73896fe5826",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18607,7 +18607,7 @@
             "generatedTestHash" : "6bc00ad48d5df253e5a6d088205e3d455ffd0a093a21f372744c4d6505df758b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18700,7 +18700,7 @@
             "generatedTestHash" : "8ee03314c5e26fef1523542f561d4ed9f66cd1a8c3df7a8245d175fc7a1c58f7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18793,7 +18793,7 @@
             "generatedTestHash" : "7ea8011e0a289020291a7800cb0f63e599af3d5d10e0a06cb4fd6b7ed85f6b73",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18886,7 +18886,7 @@
             "generatedTestHash" : "007bfedb9da3d889e5794d7746ea1c17a4d2f8a517f3b7ae3796384b8e474ae8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -18979,7 +18979,7 @@
             "generatedTestHash" : "de3b7fb3d412292cb350380189ddc8f69f9951358f5967eb071ddff3e95a5ee1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19072,7 +19072,7 @@
             "generatedTestHash" : "27e9af6ef4e98d544860235f041a50940cec51373d096cbf516e1b25c7c75275",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19165,7 +19165,7 @@
             "generatedTestHash" : "a68ef228cf55608dbe94c8a2e8dc83526cc7dd04f5b09d77f25b7460e6b0520a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19258,7 +19258,7 @@
             "generatedTestHash" : "716f810a53fcd70180259fe58d34a6e0bae0584121469d7fef34b09478b11dd5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19351,7 +19351,7 @@
             "generatedTestHash" : "34cf86e1a60c162a2cb30b5a2d2bb861b949136f9ceb0c31c8003fd3f85d60ca",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19444,7 +19444,7 @@
             "generatedTestHash" : "77518230540ffa5d5396ed7b8cc2c81078b6d2e40d6a61944c2e7309f4cb6243",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19537,7 +19537,7 @@
             "generatedTestHash" : "aef4f826cb1df2491d1206ef29a82a82fb3d34e4d83390817a8f167a326d9981",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19630,7 +19630,7 @@
             "generatedTestHash" : "08d28116c31f4243986f1f138f64e273a30388625503488279a73f9f081cb4eb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19723,7 +19723,7 @@
             "generatedTestHash" : "c56d3590b027427dccd3ba92187819eabb7d8367a50c0fe3de638a1f11e83183",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19816,7 +19816,7 @@
             "generatedTestHash" : "a265d926c76ff5e060f339001eadc609438b471ba191bc0c1cfb91f5eb4fd99a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -19909,7 +19909,7 @@
             "generatedTestHash" : "1e4ddb53131cdd7bbf09500f87d81ac9191f576c77dfd5f35926341f07b320c9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20002,7 +20002,7 @@
             "generatedTestHash" : "75668f488a4556d837ef93c090324d407128138eead64878691f8645bfc46511",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20095,7 +20095,7 @@
             "generatedTestHash" : "7d5aeb5396811f71da1d08aa222515c93878bfe36ec77148cd497ac786539623",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20188,7 +20188,7 @@
             "generatedTestHash" : "adcf5cbedf15b4fbd9582985ea2752b8bee2827391d3b05a2d2e97a75508dded",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20281,7 +20281,7 @@
             "generatedTestHash" : "2626e8aba0fa855fe60e8baaa3448e6cb60eff5c8fda0faecdc3088703c7837f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20374,7 +20374,7 @@
             "generatedTestHash" : "288afd9e66d00f9f80930f22bb770e62bd143c3ac0c5fe286259df18091c70c0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20467,7 +20467,7 @@
             "generatedTestHash" : "68d68eb55d19ea2561efb9380d80b43e8e50556592497ca79bfc9fb7e382d8ec",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20560,7 +20560,7 @@
             "generatedTestHash" : "7b651810c6141d903582cfa82d7a1fc11c209c5d90015d0c295ae5866d8db088",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20653,7 +20653,7 @@
             "generatedTestHash" : "849b5d04732ea65d70c32e20eda14cab6bed33b9ddb7deb72b3508d5f1f9c33d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20746,7 +20746,7 @@
             "generatedTestHash" : "63da2c299dea44ef5107f4a597f78abdd5e2d77f05e6146679aad7e85201558b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20839,7 +20839,7 @@
             "generatedTestHash" : "5a897e36b48e82656da32209fad6c2ec2b919597e2e1c3f1756a6d25cab4a7f6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -20932,7 +20932,7 @@
             "generatedTestHash" : "061ad3b5c38506a2b04415d99629b8b893a9a7ba35d943dbe417da1d7e3401a1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -21025,7 +21025,7 @@
             "generatedTestHash" : "b4e3547d9960ddba3a9454106adc01d88eab872e306aa41f5afa67dbd5a9285b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [
@@ -21118,7 +21118,7 @@
             "generatedTestHash" : "2e7070f0064a8ee04176870350e0a1a7139aede4c8fdbfac1da1a115627400e8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stTransactionTest/CreateTransactionInvalidEOF1Filler.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/CreateTransactionInvalidEOF1Filler.yml",
             "sourceHash" : "976e61d0480f1b5a36c3434a1ee42af95e41de4dab4d1ec570e5a7e019b2cc09"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Calls.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Calls.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "a203182339f6ffc7e863c1eb4b8a433a84db8e0d8d47ec0be130977b55bd0ba1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -383,7 +383,7 @@
             "generatedTestHash" : "a392174b161c6dfa5e6f9ab0405c8d6a12d8274fe7bd59ab36b894f17f2c1f37",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -761,7 +761,7 @@
             "generatedTestHash" : "caea71be77c63aa2691cf54314f076a7cbc6a53151f44c464923c52bba75ff34",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -1139,7 +1139,7 @@
             "generatedTestHash" : "f41ca451d9dc5585a7d611ac4274e60502df623890ad6dc28f33f890a1aac202",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -1517,7 +1517,7 @@
             "generatedTestHash" : "7d2f1d8d35e57d60cee462a593832c4be3da9574b1dafeb3a1be9321b0cc1687",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -1895,7 +1895,7 @@
             "generatedTestHash" : "d80466426c36af2ba1eb1ed1c8961c46bf05fb77b376dc165b765a202d823d04",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -2271,7 +2271,7 @@
             "generatedTestHash" : "8a03f591fffa610fb82f3f0207d800c460b43fbdeadf7414e315df24768a1af9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -2649,7 +2649,7 @@
             "generatedTestHash" : "a929851f0ce121d820e6928d180bc5d8d027b7cdd1c1a4385c696692d19329db",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -3025,7 +3025,7 @@
             "generatedTestHash" : "6273ecbc3f221974ea3bc59612bfc89d12bbd94035bd48c62930183c9b44cf03",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -3403,7 +3403,7 @@
             "generatedTestHash" : "2e55615d4a2eeda0c1eed226336c7d38c6a0f92e8647e1cfb8ebb349ef756af2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -3779,7 +3779,7 @@
             "generatedTestHash" : "fd010bab307b5c212814f4794e8c1123f01af19f91043e403637a9c9a8a1564b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -4157,7 +4157,7 @@
             "generatedTestHash" : "def67d48736cae564a78c45bee24f03c27b4496d8887d51851444ce64f132008",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -4533,7 +4533,7 @@
             "generatedTestHash" : "2c820f7e31e6f95d41dcf41be8ba79407f94b961f434718b4c949c348b4e8934",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -4909,7 +4909,7 @@
             "generatedTestHash" : "a57b322f1ebaeddf2e148bb00319d6e66646c248d4b250610a3cd494cbca111b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -5285,7 +5285,7 @@
             "generatedTestHash" : "28b9e60c9b5b21803e78350a627768fdf25df3be3863891f097eb07801d2a645",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -5663,7 +5663,7 @@
             "generatedTestHash" : "c106d23d4dc6dbd2b5fff3b225bef217502f52102b17e03e9f8e6a18afb3a861",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -6041,7 +6041,7 @@
             "generatedTestHash" : "59ccbdc5a7f7798c5e30462b057248ce0df965a50a3224da2ed748fefa345960",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -6419,7 +6419,7 @@
             "generatedTestHash" : "afa0a14edcaac0f5cea8b283cdd946c167d0980fae07b7fd079e61cd3eeabc94",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -6797,7 +6797,7 @@
             "generatedTestHash" : "39545977580007a32e3bccd208659274813e0d9f7ff71d9716048def3253067f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [
@@ -7173,7 +7173,7 @@
             "generatedTestHash" : "8bce0e00345afdd6e73a4b71db93945ac202f4b4a41a8db6436602ab09bb9ca6",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_CallsFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_CallsFiller.yml",
             "sourceHash" : "10b8edfe241c6aad4719949d126d1fc9e8660f88465d694f6f589f4e4d5408c2"
         },
         "blocks" : [

--- a/BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Execution.json
+++ b/BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Execution.json
@@ -7,7 +7,7 @@
             "generatedTestHash" : "b039e40514d009147f2b8d086ac817644156ec63ba8814a452bb318b9c41db5c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -591,7 +591,7 @@
             "generatedTestHash" : "0edc885f91b2810d1714fbc4340001f02a221b48c8ba4512ff975d8754766e5a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -1177,7 +1177,7 @@
             "generatedTestHash" : "41063c9b723dd800844cce88ec275a5a62d1ff817eb6711ecb5b2c3ca9b7918d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -1761,7 +1761,7 @@
             "generatedTestHash" : "dd2481c270b1d555c596468cc69c59aa9b367a6ab5880f137e8e008b84a55d69",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -2347,7 +2347,7 @@
             "generatedTestHash" : "4d3184d7cf68c824aedf85bb883161dbaeba31a298550c40b47f6413fe5ecd4f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -2931,7 +2931,7 @@
             "generatedTestHash" : "7a1dadb4a4e82f20db0833e86a9dcad512ff933685d8ce2a571916c41a4d92f3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -3517,7 +3517,7 @@
             "generatedTestHash" : "9b15cb505ffb217266295569debd1ac8770faee9faabc6c8f7f16b01afae1372",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -4101,7 +4101,7 @@
             "generatedTestHash" : "94629f28612c2ed558997eee984af3230072fc82323aa22857f5e49c7d22771d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -4687,7 +4687,7 @@
             "generatedTestHash" : "e374d434e7d64ec08c938105ed4924c1b5e67c0a5bb06bf5d6351cddc6b82207",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -5271,7 +5271,7 @@
             "generatedTestHash" : "336ab0c056eaad951747380067fcbc4e5ab5e06cfaa81d61f1bc518602fb3e89",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -5855,7 +5855,7 @@
             "generatedTestHash" : "b06673c10ef1f02e55458b559bca7ca7765902dbfeb144431bd810fab2b91267",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -6439,7 +6439,7 @@
             "generatedTestHash" : "e59b909c670e32ebbd06b86d7cca4a41dc32ff0c25351e34eeddea79179d7977",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -7023,7 +7023,7 @@
             "generatedTestHash" : "2c23558d851b9d98913302ac14251169b95a1cfbf5b7cd0f9d370cd34be8941a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -7607,7 +7607,7 @@
             "generatedTestHash" : "c1d76d6216fc53466cc05e0c3b20e44ccdfb9198c18fab79294b281aa046ca31",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -8191,7 +8191,7 @@
             "generatedTestHash" : "6eed0cb1e27998b9b62cfd476626f2dc5b75b7338a8e457d79a2383c68b6ec31",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -8775,7 +8775,7 @@
             "generatedTestHash" : "18a615361107c78a29652ec7d01c17233d3aad6421cdd6130ecd3f4cc183301a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -9359,7 +9359,7 @@
             "generatedTestHash" : "a04ab4fd5b3a630b2f42c7c694dcb9645fd90460a472f91b09f4978cd966ff93",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -9943,7 +9943,7 @@
             "generatedTestHash" : "96487ee31d53c523ad8749b86966599b30068cf54cb977217d365387b116af8f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -10527,7 +10527,7 @@
             "generatedTestHash" : "f20ba5e11ddbcf99f3a4655c4f0d58e891fcb46287cde9f4106a6d830b543dd8",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -11111,7 +11111,7 @@
             "generatedTestHash" : "4bdddf65d3ad784ef06fff2ce883fcff7edcaed41921e56d0732f785c58b4a7b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -11695,7 +11695,7 @@
             "generatedTestHash" : "3ee1cd52017cc39249f44ca8cbf75d4cc6a3a6f593497111239d23d741ad3d32",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -12279,7 +12279,7 @@
             "generatedTestHash" : "27766f7ae1581d38429050ac6d84fdddfc7fad0acece75aea8a8559a5df443da",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -12863,7 +12863,7 @@
             "generatedTestHash" : "c55942e1ed0aa40a87d632b882f121cfb8303aaa9e5271195b18e51fb00fcde4",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -13447,7 +13447,7 @@
             "generatedTestHash" : "48368a3a30ee2bede2fdc5e9978ad0ce415df5a0d5179ad956eadd88e4b55824",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -14033,7 +14033,7 @@
             "generatedTestHash" : "171e647e6ef642dfe2d3aec6203c6d8dcff06c4618cb648d3d6e79899034097b",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -14617,7 +14617,7 @@
             "generatedTestHash" : "7b64c5bf098d2b90b3f0d800a3c7386dd5665c1037266992d6c90b2ec50922d3",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -15201,7 +15201,7 @@
             "generatedTestHash" : "4f7c3abaa165c5dae54564896d12b10b2f36960f0893b7cc8cc765e166fc432f",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -15785,7 +15785,7 @@
             "generatedTestHash" : "4356681e57804103c0329df5c318a78cc5d3ab92c9000a4cbe4d60b47a05927e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -16369,7 +16369,7 @@
             "generatedTestHash" : "502f5a089d6407d3747d2cc03f3cac2561206868ea445c18c5807ba8f2c1df8d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -16953,7 +16953,7 @@
             "generatedTestHash" : "2fd9af47bbfd8b13acddd8f7ec6d0baa1134e277c3ec99a61da79189408b52b1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -17537,7 +17537,7 @@
             "generatedTestHash" : "e3df71159dadbf742d5ae8ea2b252a883b0fc4703bbbe999f6bf6c3988d00fa9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -18121,7 +18121,7 @@
             "generatedTestHash" : "c54daac4e30390971747eb9b5951d42c6a6d300241369c6d27f33ec5ae1cd949",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -18707,7 +18707,7 @@
             "generatedTestHash" : "a1ba9d17d0333daf354be09f9a88fe5849e8f864138e2b9cc5f0372bd6be1eca",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -19291,7 +19291,7 @@
             "generatedTestHash" : "8004a5533034acfe1df7e4c858ba5d1380168586346b38a023b57631fba336e1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -19877,7 +19877,7 @@
             "generatedTestHash" : "63e0075bd8e497abc3df049b68adb838c0f2e92b6d6c0fd5a8634f77e34326ab",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -20461,7 +20461,7 @@
             "generatedTestHash" : "12d4995fa578b46c553924481aecb2d2b6eb99ebb9380ab8e519474d7284cb8d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -21047,7 +21047,7 @@
             "generatedTestHash" : "49852590babed19fbd561594b012952e37eef9ebbea8b11d5b99ee86a7a26e8e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -21633,7 +21633,7 @@
             "generatedTestHash" : "9fbeabe71f21f944fb0f88f957de64773cb631c9c6dff41c1c94dde961dac298",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -22219,7 +22219,7 @@
             "generatedTestHash" : "faa0d90d1f01e61fe136a93adbee4a24ea96869b1061991155b05761e9a3e674",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -22803,7 +22803,7 @@
             "generatedTestHash" : "6606a3c80c55bcebc676ded9a8997ab362d8384d360af3a5cffb13363f535749",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -23389,7 +23389,7 @@
             "generatedTestHash" : "de553469bf7bfb8bbf1c4b7a46b6477ac574bd043379b63cc13daddd30bff5ff",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -23975,7 +23975,7 @@
             "generatedTestHash" : "c304bdbda7ab2bfcb341b468979bb8347f350fc9a3c8923d955add8605f4a9da",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -24561,7 +24561,7 @@
             "generatedTestHash" : "e48977a67154917294f262b23b537e99bf968a94d519822167be933694a5d5fc",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -25145,7 +25145,7 @@
             "generatedTestHash" : "7b8a21e4d860ec6ab54150ecf67271d0724f7c0e0ce813b5b50f6731a4d44cc0",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -25731,7 +25731,7 @@
             "generatedTestHash" : "4bf501ac1be4b768ecb6929240eb44101ae008658d9481ae01ca305c9aba7ab2",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -26315,7 +26315,7 @@
             "generatedTestHash" : "980c92c54853befec9dc4b06f3b0b71e2470d91aa447a5b449911d5582f26531",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -26900,7 +26900,7 @@
             "generatedTestHash" : "eee28718a6c3032dfac621b659a03a3cca15ce3b6a6a2933873f47bb23d24bfb",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -27486,7 +27486,7 @@
             "generatedTestHash" : "91d7f4d1a06d92094a46fe246df81e1554e374b77f5e29e014b953b2a678a2c7",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -28072,7 +28072,7 @@
             "generatedTestHash" : "8d398960c3466ac727a436235a1b86df1e88f9e28868ae881908e0dd2ebb8e9a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -28656,7 +28656,7 @@
             "generatedTestHash" : "b538129c7571c9dc725d8506721f23bb5ce6d80f3755e95b0940975c325f987e",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -29242,7 +29242,7 @@
             "generatedTestHash" : "2d93ab9c8778abd6e1a846b52d4fefe02de38dfc157da8055c6d458a1ba0454c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -29828,7 +29828,7 @@
             "generatedTestHash" : "f083628ff01c3b2bf8e6024c83e01b99b205e08272f9ac487eba749909fa1010",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -30414,7 +30414,7 @@
             "generatedTestHash" : "a00a9e17557cede3524d780a40d7524cbf130a940a740a5665a110b094aeca26",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -30998,7 +30998,7 @@
             "generatedTestHash" : "3d0c693efed5ea5988cf2a3e94b8bbab35b4207109cca774e39adae7f7e2b0aa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -31584,7 +31584,7 @@
             "generatedTestHash" : "1d8ea5b833245b7f866073102384cb80e600a87cba3b5027639b79e04f073f06",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -32168,7 +32168,7 @@
             "generatedTestHash" : "bf3c4b38f134d8f3c6161427cf6df738f531c6f8829998d50e95ccefd48593aa",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -32754,7 +32754,7 @@
             "generatedTestHash" : "c9edf5d05ce2e501ce383450a192ca025c0433d0642c43a4a893a81d13dfb07d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -33338,7 +33338,7 @@
             "generatedTestHash" : "7a450ce9e4dbe45964a7b0b1b51054812e310b1538f2bba83d73dea6112f1f0d",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -33924,7 +33924,7 @@
             "generatedTestHash" : "7d081087226991551ca44c940c31d3ec6f4a2e16bcc9d187b9acaf3fd0620130",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -34508,7 +34508,7 @@
             "generatedTestHash" : "57320de6e00df08a5f3089ce02f92a642bdd093b551d8fe400c662f3e1560ad9",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -35094,7 +35094,7 @@
             "generatedTestHash" : "4d5308119e377645168d245bdc375cd0547bca74ae920c8381b8371c1bb9d9f5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -35678,7 +35678,7 @@
             "generatedTestHash" : "78ee56de187a8895636b76f839b41510165f39919066ca3e6df24d4c0876ba3c",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -36264,7 +36264,7 @@
             "generatedTestHash" : "af7571847c8d595724bbc619788d25b41c63c70cb7ed6b4d129993e3f330afae",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -36848,7 +36848,7 @@
             "generatedTestHash" : "eccb3a71d20f26888ce3c9c211bb7f83e1e939596246d46fab4ee5c9c31794e5",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -37434,7 +37434,7 @@
             "generatedTestHash" : "c21efb97d1ac6bf04dd70e06dc08608f011777abd4a85f32011b10d38bd31e1a",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -38018,7 +38018,7 @@
             "generatedTestHash" : "3713e1008160f5fc7d024db4484e6084aa90e60c1ce5d5bdcc3551a28c0cc368",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -38604,7 +38604,7 @@
             "generatedTestHash" : "c8644588b8072904d8b926ce851b0fe8e78521a8426592132ce1620469510ad1",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [
@@ -39188,7 +39188,7 @@
             "generatedTestHash" : "a3421d247d69dbfd26387b945ad4e6f4eb6c64433db4dda263793f4089b0e794",
             "lllcversion" : "Error getting LLLC Version",
             "solidity" : "Version: 0.8.17-develop.2022.9.30+commit.8df45f5f.Linux.clang",
-            "source" : "src/GeneralStateTestsFiller/stCallCodes/EOF1_ExecutionFiller.yml",
+            "source" : "src/GeneralStateTestsFiller/stEIP3540/EOF1_ExecutionFiller.yml",
             "sourceHash" : "938140eb8755b9d303d1b462ab8a253351f3aa50ca1400197c63494aaf229aeb"
         },
         "blocks" : [


### PR DESCRIPTION
This PR does the following:
- Fix source path of `stEIP3540`
- Tests affected:
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1Invalid_FromEOF.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE2_EOF1_FromEOF.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1Invalid_FromEOF.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CREATE_EOF1_FromEOF.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionEOF1.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/CreateTransactionInvalidEOF1.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Calls.json`
   - `BlockchainTests/GeneralStateTests/stEIP3540/EOF1_Execution.json`
