### PR TITLE
EOF: Forbid DELEGATECALL EOF → legacy

### DIFF
--- a/EIPTests/BlockchainTests/StateTests/stEOF/stEIP3540/EOF1_Calls.json
+++ b/EIPTests/BlockchainTests/StateTests/stEOF/stEIP3540/EOF1_Calls.json
@@ -2,13 +2,13 @@
     "EOF1_Calls_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "35dc3debc50d47029a494958dc7f85cb95f520d41cc5a297c9ed51a54ffe5e98",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -342,13 +342,13 @@
     "EOF1_Calls_d10g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "d1ee3031f2ca43783cdb0e0ac64aae4f0f48715b823323d1f0ad32ea95d875e9",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -680,13 +680,13 @@
     "EOF1_Calls_d11g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "4f67e7453f6829b9b60880f652a33d0372a55cbcb6995896fa5e1d9698743ce8",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -1020,13 +1020,13 @@
     "EOF1_Calls_d1g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "41dc512f9f16314955775becaffa3ef29a061eaf9e0c16d123fb1a3f375f2803",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -1360,13 +1360,13 @@
     "EOF1_Calls_d2g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "b3062f1b87d66c4210be960a544f32107a13591d4209b229002eece1e235e187",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -1698,13 +1698,13 @@
     "EOF1_Calls_d3g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "673149f2131f77effccfb5581a0d01f2dd4d9f5fa75477eae7e067458b4ddbeb",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -2038,13 +2038,13 @@
     "EOF1_Calls_d4g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "18ab33971bb89b6ed25ba05765bb5d14f642fa41e0c412c21953050a837cf301",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -2378,13 +2378,13 @@
     "EOF1_Calls_d5g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
-            "generatedTestHash" : "81c83c992bab2755aa9eaffb4b8d26b814d025f4acf0ad1552fa43c99f4c9972",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
+            "generatedTestHash" : "1322a33931492606b0ed6cdadfe5002bc47f4194438565fc532ae8f9c7904ab8",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -2395,20 +2395,20 @@
                     "difficulty" : "0x00",
                     "extraData" : "0x00",
                     "gasLimit" : "0x05500000",
-                    "gasUsed" : "0x021783",
-                    "hash" : "0x956b7eaea0a6739781de488fb15962e4fe87e98e5089224035d2b80e282677ca",
+                    "gasUsed" : "0x01736e",
+                    "hash" : "0x9c8d8daaa53e749c1e5b2fcf896cab8ed7cfc6d53e452c1a9da64ad3e4a04fd0",
                     "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000020000",
                     "nonce" : "0x0000000000000000",
                     "number" : "0x01",
                     "parentHash" : "0x7ab357eec368046f796894a5ed3a0ff2cb1cb4f70b955585d77614b2c5d1580d",
-                    "receiptTrie" : "0x5b28f7cf138d587a28d63deeeb554a8c081dba9455b10ca04a98389c0c08a59d",
-                    "stateRoot" : "0x0cfde7d2cafa851111ac4a612823bf0b0faa103d93c7d048f12e9b14d9f500a9",
+                    "receiptTrie" : "0xddb3c4d3ac66984b82d51dc0a0415013dcfab47b4f960708e5eefc3e99119468",
+                    "stateRoot" : "0x64957845d48dd0aebb33385baae84ded00f67477d5575aca73448ca0bf1f7fc5",
                     "timestamp" : "0x03e8",
                     "transactionsTrie" : "0x31facfed4c8c5cccfcb84d5c729d7f4e254b2cfd24a6d11502ebea56bd6d2c91",
                     "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                     "withdrawalsRoot" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
                 },
-                "rlp" : "0xf90295f90218a07ab357eec368046f796894a5ed3a0ff2cb1cb4f70b955585d77614b2c5d1580da01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa00cfde7d2cafa851111ac4a612823bf0b0faa103d93c7d048f12e9b14d9f500a9a031facfed4c8c5cccfcb84d5c729d7f4e254b2cfd24a6d11502ebea56bd6d2c91a05b28f7cf138d587a28d63deeeb554a8c081dba9455b10ca04a98389c0c08a59db901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018405500000830217838203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421f876f874800a830aae6094b94f5374fce5edbc8e2a8697c15331677e6ebf0b8094224f5374fce5edbc8e2a8697c15331677e6ebf0b1ca0034580ff109b3b5d3415f5ccd85eda13aeceea7b18ce1b942616360dcb803650a0168efdbf87b181399a2ecf7918e8e3f375e4a432792ba93fb3f797eb5ce3612bc0c0",
+                "rlp" : "0xf90295f90218a07ab357eec368046f796894a5ed3a0ff2cb1cb4f70b955585d77614b2c5d1580da01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa064957845d48dd0aebb33385baae84ded00f67477d5575aca73448ca0bf1f7fc5a031facfed4c8c5cccfcb84d5c729d7f4e254b2cfd24a6d11502ebea56bd6d2c91a0ddb3c4d3ac66984b82d51dc0a0415013dcfab47b4f960708e5eefc3e99119468b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800184055000008301736e8203e800a000000000000000000000000000000000000000000000000000000000000200008800000000000000000aa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421f876f874800a830aae6094b94f5374fce5edbc8e2a8697c15331677e6ebf0b8094224f5374fce5edbc8e2a8697c15331677e6ebf0b1ca0034580ff109b3b5d3415f5ccd85eda13aeceea7b18ce1b942616360dcb803650a0168efdbf87b181399a2ecf7918e8e3f375e4a432792ba93fb3f797eb5ce3612bc0c0",
                 "transactions" : [
                     {
                         "data" : "0x224f5374fce5edbc8e2a8697c15331677e6ebf0b",
@@ -2450,7 +2450,7 @@
             "withdrawalsRoot" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
         },
         "genesisRLP" : "0xf90219f90213a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0dd374fb6a5b68b2563e65feb24a1056afec68b5f949325a0ed00002304091b2fa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808405500000808000a000000000000000000000000000000000000000000000000000000000000200008800000000000000000ba056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421c0c0c0",
-        "lastblockhash" : "0x956b7eaea0a6739781de488fb15962e4fe87e98e5089224035d2b80e282677ca",
+        "lastblockhash" : "0x9c8d8daaa53e749c1e5b2fcf896cab8ed7cfc6d53e452c1a9da64ad3e4a04fd0",
         "network" : "Cancun",
         "postState" : {
             "0x104f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
@@ -2493,9 +2493,7 @@
                 "code" : "0xef0001010004020001002b0300000000000006600060006000600073e94f5374fce5edbc8e2a8697c15331677e6ebf0b620186a0f4600055600160015500",
                 "nonce" : "0x00",
                 "storage" : {
-                    "0x00" : "0x01",
-                    "0x01" : "0x01",
-                    "0x0a" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    "0x01" : "0x01"
                 }
             },
             "0x234f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
@@ -2541,7 +2539,7 @@
                 }
             },
             "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
-                "balance" : "0x83ab62",
+                "balance" : "0x8a1434",
                 "code" : "0x",
                 "nonce" : "0x01",
                 "storage" : {
@@ -2718,13 +2716,13 @@
     "EOF1_Calls_d6g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "d1f6463cffe00e1d50f9a25a9590a67f56349c46ec73937a740d7f09e75287ce",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -3056,13 +3054,13 @@
     "EOF1_Calls_d7g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "7b0736e1f2771167dccedb3c0dfbace3348f5814f7ac73753c851cf042261641",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -3396,13 +3394,13 @@
     "EOF1_Calls_d8g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "f3d860b2eb76917661dbde66b5bf964483fb52e4fde5ed08a0c36170bc617e42",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {
@@ -3736,13 +3734,13 @@
     "EOF1_Calls_d9g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
             "generatedTestHash" : "bbcf0b18ac8aac12f7bbad65a2bacf38c9a8e5510cbb4198bcf408f45bbd4973",
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "blocks" : [
             {

--- a/EIPTests/StateTests/stEOF/stEIP3540/EOF1_Calls.json
+++ b/EIPTests/StateTests/stEOF/stEIP3540/EOF1_Calls.json
@@ -2,9 +2,9 @@
     "EOF1_Calls" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evmone-t8n 0.10.0-dev+commit.42119423",
-            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.899b8f06.Darwin.appleclang",
-            "generatedTestHash" : "5a2b6aa6acb70636f6875bad469b27cb92b7c5a114fed513cb4f58d2d8c504a6",
+            "filling-rpc-server" : "evmone-t8n 0.11.0-dev+commit.7f9949f9",
+            "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.e5e3eb4e.Linux.g++",
+            "generatedTestHash" : "2b829276fefc29ca69aa98da8964ca32e83475ed7622f42ed88d56975bc0586c",
             "labels" : {
                 "0" : "legacy_call_eof",
                 "1" : "legacy_delegatecall_eof",
@@ -19,10 +19,10 @@
                 "8" : "eof_call_eof",
                 "9" : "eof_delegatecall_eof"
             },
-            "lllcversion" : "Error getting LLLC Version",
-            "solidity" : "Version: 0.8.18-develop.2023.3.31+commit.469d6d4d.mod.Darwin.appleclang",
+            "lllcversion" : "Version: 0.5.14-develop.2022.6.30+commit.401d5358.mod.Linux.g++",
+            "solidity" : "Version: 0.8.18-develop.2022.12.14+commit.a9fe05e8.Linux.g++",
             "source" : "src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml",
-            "sourceHash" : "d5b369f884874ab4880de23816090eb731261c7f56d1077fab1bc96b3006886e"
+            "sourceHash" : "ba0436bc36c757e06331e6a7b969fe48318a3930a50c23bd9dc25dfe555243fb"
         },
         "env" : {
             "currentBaseFee" : "0x0a",
@@ -87,7 +87,7 @@
                     "txbytes" : "0xf874800a830aae6094b94f5374fce5edbc8e2a8697c15331677e6ebf0b8094204f5374fce5edbc8e2a8697c15331677e6ebf0b1ba08b276a9512cf27bc7cc28964eb56e398043d06deaeb254a6435c3ca179a2154ca0371b2fa94e6eafc800595f77a4824bc23df83fbfbd2402efb0095959dd669860"
                 },
                 {
-                    "hash" : "0x0cfde7d2cafa851111ac4a612823bf0b0faa103d93c7d048f12e9b14d9f500a9",
+                    "hash" : "0x64957845d48dd0aebb33385baae84ded00f67477d5575aca73448ca0bf1f7fc5",
                     "indexes" : {
                         "data" : 5,
                         "gas" : 0,

--- a/src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml
+++ b/src/EIPTestsFiller/StateTests/stEOF/stEIP3540/EOF1_CallsFiller.yml
@@ -264,9 +264,9 @@ EOF1_Calls:
             '1': '1'
         224f5374fce5edbc8e2a8697c15331677e6ebf0b:
           storage:
-            '0': '1'
+            '0': '0'  # DELEGATECALL fails because disallowed.
             '1': '1'
-            '10': 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+            '10': '0'
 
     - indexes:
        data: ':label eof_staticcall_legacy_failure'


### PR DESCRIPTION
According to EIP-3540 updated by
https://github.com/ethereum/EIPs/pull/6359
a DELEGATECALL from EOF to legacy code is disallowed.

This updates expectations in the single test case of DELEGATECALL EOF → legacy.