### PR TITLE
Replace invalid JSON strings

### DIFF
--- a/BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflow.json
+++ b/BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflow.json
@@ -2,7 +2,7 @@
     "ValueOverflow_d0g0v0_Berlin" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "3870e616b76f5b74ccc957afd0ca86d851f246baea1ab1aafa8fb95835e536f0",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -81,7 +81,7 @@
     "ValueOverflow_d0g0v0_Byzantium" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "9773a36d6ca1c5fe52542bee46d7510cb61e54c580006143356a842e62fe7d66",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -160,7 +160,7 @@
     "ValueOverflow_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "5f1fbb006e8a0ff287599c0606540e3d6441bf9be262d2c3841da7be8cd4be39",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -243,7 +243,7 @@
     "ValueOverflow_d0g0v0_Constantinople" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "bd8541db60265876812ed6ea87668841b75c4628f22bb86b7725c4694ac3d13a",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -322,7 +322,7 @@
     "ValueOverflow_d0g0v0_ConstantinopleFix" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "6a217ee37f7f3ef34946ad24845e789ebb7b9ecf671361fbce73327689bb21aa",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -401,7 +401,7 @@
     "ValueOverflow_d0g0v0_EIP150" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "3e97036f37b30c4b22f7816fb9f8321623ec4dd8646b0ab9c76fcf87371a36e3",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -480,7 +480,7 @@
     "ValueOverflow_d0g0v0_EIP158" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "430c6c87a747579dad348b3c1f99836b316270d9aa8390de6a59eb51c130f533",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -559,7 +559,7 @@
     "ValueOverflow_d0g0v0_Frontier" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "f38373e68542f6044f88a6642e827cf60c68b2bd2a1e32e8729030279ffbe050",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -638,7 +638,7 @@
     "ValueOverflow_d0g0v0_Homestead" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "1810c734278b7882cc6ee99bcb42b071850d6653e2eae455910090731f831de1",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -717,7 +717,7 @@
     "ValueOverflow_d0g0v0_Istanbul" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "059402440aebe73263d0d256375c60e628e9ee26817442af82f95aa8de4c6b7e",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -796,7 +796,7 @@
     "ValueOverflow_d0g0v0_London" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "00cc97c0d5bfc8889c4eec8691989ca3e51be9fd5f036b5bc809e16bb8f4a13b",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -876,7 +876,7 @@
     "ValueOverflow_d0g0v0_Merge" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "2fdad2c7b41daf3c66be9e5d3ff4c2ac6a71a60b724b6ee8b7ee43e0a1b877ea",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",
@@ -956,7 +956,7 @@
     "ValueOverflow_d0g0v0_Shanghai" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "acbb9927f9a82be2e55e4706ac5eeaab9c483a2200a9567023129ffe3a63a1ca",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/createBlobhashTx.json
+++ b/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/createBlobhashTx.json
@@ -2,7 +2,7 @@
     "createBlobhashTx_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "BLOB002",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "c0ea7fddafdaca2309074690352f948170ef3bedc1beeb07f4ba8959c68a17ed",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/emptyBlobhashList.json
+++ b/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/emptyBlobhashList.json
@@ -2,7 +2,7 @@
     "emptyBlobhashList_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "BLOB000",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "085283f07ecb480dda2dfcd1df74998ea1c726a6e3ee00ca8fd17e53b4947254",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json
+++ b/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json
@@ -2,7 +2,7 @@
     "opcodeBlobhashOutOfRange_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "BLOB003, BLOB004",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "29237835ac38ee3f2ec7b6d9eb065d9f0724872f3e6f422ff468cae2db4640b4",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/wrongBlobhashVersion.json
+++ b/EIPTests/BlockchainTests/StateTests/stEIP4844-blobtransactions/wrongBlobhashVersion.json
@@ -2,7 +2,7 @@
     "wrongBlobhashVersion_d0g0v0_Cancun" : {
         "_info" : {
             "comment" : "BLOB001",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "6913887841d864c33fe56990f776623928ab33ea6804df04599bad4077aca60d",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/StateTests/stEIP4844-blobtransactions/createBlobhashTx.json
+++ b/EIPTests/StateTests/stEIP4844-blobtransactions/createBlobhashTx.json
@@ -2,7 +2,7 @@
     "createBlobhashTx" : {
         "_info" : {
             "comment" : "BLOB002",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "49882df02962c3d842158b1897d25bb38d2d724d81ee8c2a33de2d2e5affbd94",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/StateTests/stEIP4844-blobtransactions/emptyBlobhashList.json
+++ b/EIPTests/StateTests/stEIP4844-blobtransactions/emptyBlobhashList.json
@@ -2,7 +2,7 @@
     "emptyBlobhashList" : {
         "_info" : {
             "comment" : "BLOB000",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "891b8bd809b054b08bef77902d8af854336efb022b3d63e6c56807f426748beb",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/StateTests/stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json
+++ b/EIPTests/StateTests/stEIP4844-blobtransactions/opcodeBlobhashOutOfRange.json
@@ -2,7 +2,7 @@
     "opcodeBlobhashOutOfRange" : {
         "_info" : {
             "comment" : "BLOB003, BLOB004",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "396dfe4ea0c2560078ca06f3c2e8d4e0f5e2782a51699c96e044b09ae4e243dc",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/EIPTests/StateTests/stEIP4844-blobtransactions/wrongBlobhashVersion.json
+++ b/EIPTests/StateTests/stEIP4844-blobtransactions/wrongBlobhashVersion.json
@@ -2,7 +2,7 @@
     "wrongBlobhashVersion" : {
         "_info" : {
             "comment" : "BLOB001",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.9de66016.Linux.g++",
             "generatedTestHash" : "16fd0c5e095f3bfa03b3d86442618c05ff49f8e23beff99820081601f887e9c9",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",

--- a/GeneralStateTests/stTransactionTest/ValueOverflow.json
+++ b/GeneralStateTests/stTransactionTest/ValueOverflow.json
@@ -2,7 +2,7 @@
     "ValueOverflow" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "Nimbus-t8n 0.1.2\n[0m",
+            "filling-rpc-server" : "Nimbus-t8n 0.1.2",
             "filling-tool-version" : "retesteth-0.3.1-shanghai+commit.8eac02f7.Linux.g++",
             "generatedTestHash" : "6c94cdf6c546ef79134c26e22301ffab988b8591268da166ac32cb1cb1a7cf2e",
             "lllcversion" : "Version: 0.5.14-develop.2023.5.21+commit.a096d7a9.mod.Linux.g++",


### PR DESCRIPTION
`Nimbus-t8n 0.1.2\n[0m` is an invalid json string

![image](https://github.com/ethereum/tests/assets/5773434/42d838e6-13b4-475b-aa82-d1ae84582636)


I noticed it when Reth state tests started failing: https://github.com/paradigmxyz/reth/actions/runs/5337139311/jobs/9672776651?pr=3307#step:7:105