### PR TITLE
fix: redundancies in 04_multitestFiller.yml

### DIFF
--- a/docs/tutorial_samples/04_multitestFiller.yml
+++ b/docs/tutorial_samples/04_multitestFiller.yml
@@ -51,8 +51,6 @@
     - :abi val2Storage(uint256,uint256) 0x11 0x11 # 5
     - :abi val2Storage(uint256,uint256) 0x11 0x11 # 6
     - :label ten-ten :abi val2Storage(uint256,uint256) 0x10 0x10
-    - :label ten-ten :abi val2Storage(uint256,uint256) 0x10 0x10
-    - :label ten-ten :abi val2Storage(uint256,uint256) 0x10 0x10
     gasLimit:
     - '80000000'
     gasPrice: 10

--- a/docs/tutorial_samples/04_multitestFiller.yml
+++ b/docs/tutorial_samples/04_multitestFiller.yml
@@ -77,8 +77,7 @@
     - indexes:
         data: 
         - !!int 1
-        - !!int 3
-        - 4-6
+        - 3-6
         gas:  !!int 0
         value: !!int 0
       network:


### PR DESCRIPTION
- remove the redundant definitions of the `ten-ten` label in the 04_multitestFiller test
- include the `!!int 3` into the int range that follows it