### PR TITLE
fix: Add missing 'let' declaration in createEOF1Code function

### DIFF
--- a/src/Templates/EOF1/EOF1-generator.js
+++ b/src/Templates/EOF1/EOF1-generator.js
@@ -90,7 +90,7 @@ const encode = hash => {
 // Create a valid code section in an EOF1 structure
 const createEOF1Code = (codeList, maxStacks) => {
     // Start from a valid copy
-    eof1 = cloneEof1Good()
+    let eof1 = cloneEof1Good()
 
     // Size of sections
     eof1.sections[0].size = codeList.length*4


### PR DESCRIPTION
Fixed a potential scope issue in EOF1-generator.js by adding a proper 'let' declaration for the 'eof1' variable in the createEOF1Code function. This prevents the variable from becoming an implicit global, which could cause unexpected behavior when the function is called multiple times. The change improves code reliability and follows JavaScript best practices without altering functionality