### PR TITLE
chore: bump license year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014-2025 Ethereum Foundation
+Copyright 2014-2026 Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## Summary
Updated copyright year in LICENSE file(s).

**Before:** 2025
**After:** 2026

Routine maintenance to keep copyright notices up to date.